### PR TITLE
storage/semconv: fix rename_metrics parsing, corroborate renames against semconv

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -457,5 +457,36 @@ For `test` in semconv 1.1.0, this matches the metric's earlier names (e.g.
 `test.counter` in 1.0.0) declared by the schema's `versions` section and merges
 the results under the queried name `test`.
 
+### Warnings
+
+A schema names metrics only by their surface name, so nothing in it separates a
+genuine rename from an edge joining two unrelated metrics that held the same name
+at different times — a name renamed away may later be reused. Before following a
+rename, Prometheus therefore checks it against the semconv files of the versions
+it connects: `unit` and `instrument` describe what a metric is rather than what it
+is called, and semantic conventions forbid a stable metric from changing either,
+so a disagreement means the two names denote different metrics.
+
+The query still returns results in every case below, with a warning attached:
+
+- **The rename was contradicted.** The schema links the queried metric to a name
+  that a semconv file declares with a different unit or instrument. That rename is
+  not followed and its series are left out, because combining metrics measured in
+  different units yields meaningless numbers.
+- **The rename could not be corroborated.** A name a rename refers to is not
+  declared as a metric by the semconv of the version it belongs to, so there is
+  nothing to check it against. The rename is still followed: a registry may
+  legitimately ship semconv files trimmed to the metrics its operator cares about.
+- **The queried metric's identity is unknown.** No semconv version declares the
+  queried name, or the versions that do disagree on what it is — which happens when
+  a name was retired and later reused. No rename of it can be checked, so all of
+  them are followed unchecked and the result may merge unrelated series.
+- **The metric name is ambiguous.** More than one group in the anchor semconv
+  declares the same `metric_name`, so its unit and attributes have no single
+  answer and the result may fuse distinct metrics.
+
+Warnings are surfaced as PromQL warnings, and appear in the `warnings` field of an
+API response and in the expression browser.
+
 This feature is experimental: the matcher names, the registry layout, and the
 `semconv` configuration block are subject to change.

--- a/docs/querying/basics.md
+++ b/docs/querying/basics.md
@@ -356,9 +356,13 @@ against the active registry under the `registry/` namespace. Prometheus uses
 the registry embedded in the binary by default, but operators can configure a
 local-files or remote-archive registry via the `semconv` block, which fully
 replaces the embedded registry. The matcher values are registry paths, not
-locations; arbitrary HTTP URLs and filesystem paths are rejected. See
+locations; arbitrary HTTP URLs and filesystem paths are rejected.
+
+Renames are checked against the semconv files before being followed, and a query
+returns a warning when one is contradicted, cannot be checked, or the metric name
+is ambiguous. See
 [Semconv Versioned Read](../feature_flags.md#semconv-versioned-read) for
-the supported registry layout, examples, and the limitations of the
+the supported registry layout, examples, the warnings, and the limitations of the
 fan-out.
 
 ### Range Vector Selectors

--- a/storage/semconv/bench_test.go
+++ b/storage/semconv/bench_test.go
@@ -1,0 +1,182 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/semconv"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/teststorage"
+)
+
+// benchSemconv declares the metric under test with one attribute, plus bench.solo,
+// which no schema below renames. A query for bench.solo therefore fans out to a
+// single variant with nothing rewritten but __name__, which is the common shape.
+const benchSemconv = `
+groups:
+  - id: registry.attrs
+    type: attribute_group
+    brief: "Attributes"
+    attributes:
+      - id: %[2]s
+        type: string
+        stability: stable
+        brief: "An attribute"
+        examples: ["a"]
+  - id: metric.%[1]s
+    type: metric
+    brief: "A metric"
+    stability: stable
+    metric_name: %[1]s
+    instrument: counter
+    unit: By
+    attributes:
+      - ref: %[2]s
+  - id: metric.bench.solo
+    type: metric
+    brief: "A metric no schema renames"
+    stability: stable
+    metric_name: bench.solo
+    instrument: counter
+    unit: By
+    attributes:
+      - ref: attr.solo
+`
+
+// benchMetricRenameSchema renames only the metric, so nothing a returned series
+// carries is rewritten apart from __name__.
+const benchMetricRenameSchema = `
+file_format: 1.1.0
+schema_url: https://example.com/schemas/1.1.0
+versions:
+  1.0.0:
+  1.1.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            bench.old: bench.new
+`
+
+// benchAttributeRenameSchema renames the metric and one of its attributes, which
+// is what forces a variant to be buffered and re-sorted.
+const benchAttributeRenameSchema = `
+file_format: 1.1.0
+schema_url: https://example.com/schemas/1.1.0
+versions:
+  1.0.0:
+  1.1.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            bench.old: bench.new
+        - rename_attributes:
+            attribute_map:
+              attr.old: attr.new
+            apply_to_metrics:
+              - bench.new
+`
+
+// benchAttrOf gives each benchmark metric the attribute name its era declares.
+var benchAttrOf = map[string]string{
+	"bench.old":  "attr.old",
+	"bench.new":  "attr.new",
+	"bench.solo": "attr.solo",
+}
+
+// benchStorage builds a storage holding seriesCount series, spread evenly over the
+// given metric names.
+func benchStorage(b *testing.B, schema string, seriesCount int, metrics ...string) storage.Storage {
+	b.Helper()
+	wrapped, err := semconv.AwareStorageWithRegistry(teststorage.New(b), map[string][]byte{
+		"registry.yaml": []byte(schema),
+		"1.0.0":         []byte(fmt.Sprintf(benchSemconv, "bench.old", "attr.old")),
+		"1.1.0":         []byte(fmt.Sprintf(benchSemconv, "bench.new", "attr.new")),
+	})
+	require.NoError(b, err)
+
+	app := wrapped.Appender(context.Background())
+	for i := range seriesCount {
+		metric := metrics[i%len(metrics)]
+		attr := benchAttrOf[metric]
+		// Zero-padded so the stored order is stable and the series are spread
+		// across both eras rather than clustered.
+		lset := labels.FromStrings(model.MetricNameLabel, metric, attr, fmt.Sprintf("v%05d", i))
+		_, err := app.Append(0, lset, 1, float64(i))
+		require.NoError(b, err)
+	}
+	require.NoError(b, app.Commit())
+	return wrapped
+}
+
+// BenchmarkSelectFanOut measures a fanned-out Select, drained the way PromQL drains
+// one. The cases differ in how many variants the query fans out to and whether an
+// attribute is renamed, which is what decides whether a variant has to be buffered
+// and sorted before the merge: a __name__-only rewrite replaces the same value in
+// every series of a variant and so cannot reorder it.
+func BenchmarkSelectFanOut(b *testing.B) {
+	for _, sc := range []struct {
+		name    string
+		schema  string
+		query   string
+		metrics []string
+	}{
+		// One variant, nothing rewritten but __name__: no buffering at all.
+		{"no rename", benchMetricRenameSchema, "bench.solo", []string{"bench.solo"}},
+		// Two variants, still only __name__ rewritten: no buffering.
+		{"metric rename only", benchMetricRenameSchema, "bench.new", []string{"bench.old", "bench.new"}},
+		// Two variants with an attribute rewritten: buffered and sorted.
+		{"attribute rename", benchAttributeRenameSchema, "bench.new", []string{"bench.old", "bench.new"}},
+	} {
+		for _, seriesCount := range []int{100, 10000} {
+			b.Run(fmt.Sprintf("%s/%d series", sc.name, seriesCount), func(b *testing.B) {
+				s := benchStorage(b, sc.schema, seriesCount, sc.metrics...)
+				matchers := []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, sc.query),
+					labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.1.0"),
+					labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					q, err := s.Querier(0, 10)
+					require.NoError(b, err)
+
+					var series, samples int
+					set := q.Select(context.Background(), false, nil, matchers...)
+					for set.Next() {
+						series++
+						it := set.At().Iterator(nil)
+						for it.Next() == chunkenc.ValFloat {
+							samples++
+						}
+					}
+					require.NoError(b, set.Err())
+					require.NoError(b, q.Close())
+					if series != seriesCount {
+						b.Fatalf("got %d series, want %d", series, seriesCount)
+					}
+				}
+			})
+		}
+	}
+}

--- a/storage/semconv/engine.go
+++ b/storage/semconv/engine.go
@@ -15,6 +15,7 @@ package semconv
 
 import (
 	"errors"
+	"fmt"
 	"iter"
 	"slices"
 	"strings"
@@ -247,6 +248,13 @@ func applyVersionRenames(matchers []*labels.Matcher, renames versionRenames) []*
 type queryContext struct {
 	// labelMapping is a mapping to the requested OTel semantic conventions version.
 	labelMapping *labelMapping
+
+	// warnings holds problems found while resolving the query that do not stop
+	// it from being answered, but do mean the answer may fuse or omit series:
+	// an ambiguously declared metric name, or a schema rename edge that the
+	// semconv files contradict. They are surfaced through Warnings() so a user
+	// is told the result is suspect instead of silently trusting it.
+	warnings []string
 }
 
 // getSemconv returns the semconv parsed from url, fetching it via the
@@ -311,6 +319,13 @@ func (e *schemaEngine) findMatcherVariants(semconvURL, schemaURL string, origina
 		return [][]*labels.Matcher{matchers}, queryContext{}, nil
 	}
 
+	var warnings []string
+	if slices.Contains(sc.ambiguousMetrics, metricName) {
+		warnings = append(warnings, fmt.Sprintf(
+			"metric %q is declared by more than one group in semconv %s; its attributes and unit are ambiguous and results may fuse distinct metrics",
+			metricName, sc.version))
+	}
+
 	// Generate schema-version rename variants. In production schemaURL is always
 	// set (classifyMatchers gates fan-out on it); the empty case is reached only
 	// by direct unit tests and falls through to the unmodified matchers.
@@ -327,10 +342,13 @@ func (e *schemaEngine) findMatcherVariants(semconvURL, schemaURL string, origina
 		// labels instead of splitting on the renamed attribute. Recomputed per
 		// query on purpose: it is a pure function of the cached schema/semconv and
 		// costs only a few map ops, far less than the fan-out it feeds.
-		attrRenames = buildAttributeRenameMap(sc.version, &schema, sc.attributesPerMetric[metricName])
+		attrRenames = buildAttributeRenameMap(sc.version, &schema, sc.attributesOf(metricName))
 	}
 
-	return allVariants, queryContext{labelMapping: buildLabelMapping(metricName, attrRenames)}, nil
+	return allVariants, queryContext{
+		labelMapping: buildLabelMapping(metricName, attrRenames),
+		warnings:     warnings,
+	}, nil
 }
 
 // transformSeries returns the series labels rewritten to the canonical OTel

--- a/storage/semconv/engine.go
+++ b/storage/semconv/engine.go
@@ -115,10 +115,11 @@ type renameValidator struct {
 	schema *otelSchema
 	lookup metricLookup
 
-	// anchorName/anchorVersion/anchorDef describe the metric the query asked
-	// for. anchorKnown is false when the anchor semconv does not declare it, in
-	// which case there is no identity to compare hops against and no check is
-	// possible.
+	// anchorName/anchorVersion/anchorDef describe the metric the query asked for.
+	// anchorVersion is the queried semconv version where it declares the name, and
+	// otherwise the version the identity was recovered from; see
+	// identityFromOwnEra. anchorKnown is false only when no version settles what
+	// the name denotes, leaving no identity to compare hops against.
 	anchorName    string
 	anchorVersion string
 	anchorDef     metricDef
@@ -130,15 +131,56 @@ type renameValidator struct {
 
 func newRenameValidator(schema *otelSchema, lookup metricLookup, anchor semconv, anchorName string) *renameValidator {
 	def, known := anchor.metrics[anchorName]
+	version := anchor.version
+	if !known {
+		// The anchor semconv does not declare the queried name, which is an
+		// ordinary thing to query: the walk deliberately supports asking for a name
+		// the anchor version has already renamed away. Rather than give up on
+		// checking anything, take the metric's identity from a version where the
+		// name is the current one.
+		// version stays the queried one when this fails, so the warning that
+		// follows names the semconv the user actually asked for.
+		if eraDef, eraVersion, eraKnown := identityFromOwnEra(schema, lookup, anchorName); eraKnown {
+			def, version, known = eraDef, eraVersion, true
+		}
+	}
 	return &renameValidator{
 		schema:        schema,
 		lookup:        lookup,
 		anchorName:    anchorName,
-		anchorVersion: anchor.version,
+		anchorVersion: version,
 		anchorDef:     def,
 		anchorKnown:   known,
 		seen:          map[string]struct{}{},
 	}
+}
+
+// identityFromOwnEra resolves what name meant at a version where it is the current
+// name, for use when the queried semconv version does not declare it.
+//
+// It declines to answer when the schema retires the name and later reintroduces it
+// and the two eras disagree on what the metric is, because then there is no single
+// answer to what the queried name denotes and picking one would corroborate hops
+// against an identity the user never asked for.
+func identityFromOwnEra(schema *otelSchema, lookup metricLookup, name string) (metricDef, string, bool) {
+	var (
+		found   metricDef
+		version string
+		ok      bool
+	)
+	for _, era := range schema.eraVersionsOf(name) {
+		def, declared, _ := lookup(era, name)
+		if !declared {
+			continue
+		}
+		if ok && !def.sameMetricAs(found) {
+			return metricDef{}, "", false
+		}
+		if !ok {
+			found, version, ok = def, era, true
+		}
+	}
+	return found, version, ok
 }
 
 func (rv *renameValidator) warn(format string, args ...any) {
@@ -195,11 +237,22 @@ func (rv *renameValidator) hopTarget(r versionRenames, from string) (to, version
 // edge, but a registry may legitimately ship a semconv trimmed to the metrics its
 // operator cares about, and dropping variants over that would lose real series.
 func (rv *renameValidator) allowEdge(r versionRenames, from string) bool {
-	if rv == nil || !rv.anchorKnown {
+	if rv == nil {
 		return true
 	}
 	to, version, ok := rv.hopTarget(r, from)
 	if !ok {
+		return true
+	}
+	if !rv.anchorKnown {
+		// No semconv version declares the queried name, or the ones that do
+		// disagree on what it is. Every hop is then traversed unchecked, which is
+		// reported rather than left silent: this is the case the corroboration
+		// exists for, so a caller should know it did not run. Reported only here,
+		// where a metric rename is actually being followed, so a query that crosses
+		// no rename says nothing.
+		rv.warn("metric %q is not declared by semconv %s, and no other version of it settles what the metric is; schema renames of it are being followed without corroboration and may merge unrelated series",
+			rv.anchorName, rv.anchorVersion)
 		return true
 	}
 

--- a/storage/semconv/engine.go
+++ b/storage/semconv/engine.go
@@ -105,16 +105,40 @@ func (e *schemaEngine) metricLookup(semconvURL string) metricLookup {
 // upstream lints it to be exactly "metric.<metric_name>"
 // (policies/yaml_schema.rego), so it is renamed in lockstep with the metric and
 // comparing ids across an edge only restates whether the name changed.
+// Checks are made against the metric the query asked for — the anchor — and not
+// between an edge's own two endpoints. A metric name that was renamed away is
+// free to be reused later by an unrelated metric, and an edge describing that
+// earlier rename is perfectly self-consistent while having nothing to do with the
+// metric now carrying the name. Only comparing each hop back to the anchor
+// catches that, which is the case the schema format cannot express at all.
 type renameValidator struct {
 	schema *otelSchema
 	lookup metricLookup
+
+	// anchorName/anchorVersion/anchorDef describe the metric the query asked
+	// for. anchorKnown is false when the anchor semconv does not declare it, in
+	// which case there is no identity to compare hops against and no check is
+	// possible.
+	anchorName    string
+	anchorVersion string
+	anchorDef     metricDef
+	anchorKnown   bool
 
 	warnings []string
 	seen     map[string]struct{}
 }
 
-func newRenameValidator(schema *otelSchema, lookup metricLookup) *renameValidator {
-	return &renameValidator{schema: schema, lookup: lookup, seen: map[string]struct{}{}}
+func newRenameValidator(schema *otelSchema, lookup metricLookup, anchor semconv, anchorName string) *renameValidator {
+	def, known := anchor.metrics[anchorName]
+	return &renameValidator{
+		schema:        schema,
+		lookup:        lookup,
+		anchorName:    anchorName,
+		anchorVersion: anchor.version,
+		anchorDef:     def,
+		anchorKnown:   known,
+		seen:          map[string]struct{}{},
+	}
 }
 
 func (rv *renameValidator) warn(format string, args ...any) {
@@ -126,56 +150,73 @@ func (rv *renameValidator) warn(format string, args ...any) {
 	rv.warnings = append(rv.warnings, msg)
 }
 
-// allowEdge reports whether the walk may traverse version r's renames starting
-// from metric name from. A nil validator allows everything, which is the
-// behaviour when no semconv is available to check against.
-//
-// It rejects an edge only on positive contradiction — both endpoints declared,
-// but with a different unit or instrument — because fusing metrics measured in
-// different units yields numerically meaningless results, which is worse than
-// returning less data. Every other suspicious case is reported and still
-// traversed: a name missing from a version's semconv is a strong hint of a
-// mis-authored edge, but a registry may legitimately ship a semconv trimmed to
-// the metrics its operator cares about, and dropping variants over that would
-// lose real series.
-func (rv *renameValidator) allowEdge(r versionRenames, from string) bool {
-	if rv == nil {
-		return true
-	}
-	older, newer, ok := r.renameDirection(from)
-	if !ok {
+// hopTarget returns the metric name traversing version r's renames from name
+// produces, and the version that name is the current one at. ok is false when r
+// renames no metric from name, or when the name it produces belongs to a version
+// outside the schema's history.
+func (rv *renameValidator) hopTarget(r versionRenames, from string) (to, version string, ok bool) {
+	older, newer, renamed := r.renameDirection(from)
+	if !renamed {
 		// An attribute-only hop renames no metric, so there is no metric
 		// identity to corroborate.
-		return true
+		return "", "", false
 	}
+	if from != newer {
+		// Walking forward: the hop applies the rename and produces the newer
+		// name, which is the current one from this version on.
+		return newer, r.version, true
+	}
+	// Walking back in time: the hop undoes the rename and produces the older
+	// name, which was current up to the version before this one.
 	predecessor, hasPredecessor := rv.schema.predecessorOf(r.version)
 	if !hasPredecessor {
-		// The rename is recorded at the schema's earliest version, so the
-		// version the older name belonged to is outside the schema's history.
+		return "", "", false
+	}
+	return older, predecessor, true
+}
+
+// allowEdge reports whether the walk may traverse version r's renames starting
+// from metric name from. A nil validator allows everything, as does an anchor the
+// semconv does not declare, since then there is no identity to compare against.
+//
+// The name this hop produces is compared against the anchor — the metric the
+// query asked for — rather than against the other end of the edge. An edge can be
+// entirely self-consistent and still be irrelevant: once a name has been renamed
+// away it is free for an unrelated metric to reuse later, and the old edge then
+// links the reused name to a metric it has nothing to do with. Comparing the two
+// endpoints to each other would approve that edge, because in their own era they
+// really were the same metric.
+//
+// It rejects a hop only on positive contradiction — the produced name is
+// declared, but as a different unit or instrument than the anchor — because
+// fusing metrics measured in different units yields numerically meaningless
+// results, which is worse than returning less data. A name a version's semconv
+// does not declare is reported and still traversed: it hints at a mis-authored
+// edge, but a registry may legitimately ship a semconv trimmed to the metrics its
+// operator cares about, and dropping variants over that would lose real series.
+func (rv *renameValidator) allowEdge(r versionRenames, from string) bool {
+	if rv == nil || !rv.anchorKnown {
+		return true
+	}
+	to, version, ok := rv.hopTarget(r, from)
+	if !ok {
 		return true
 	}
 
-	oldDef, oldDeclared, oldKnown := rv.lookup(predecessor, older)
-	newDef, newDeclared, newKnown := rv.lookup(r.version, newer)
-	if !oldKnown || !newKnown {
+	def, declared, known := rv.lookup(version, to)
+	if !known {
+		// No semconv shipped for that version, so the hop cannot be checked.
 		return true
 	}
-
-	switch {
-	case !oldDeclared && !newDeclared:
-		rv.warn("schema version %s renames %q to %q but neither name is declared as a metric by semconv %s or %s; the rename could not be corroborated",
-			r.version, older, newer, predecessor, r.version)
-	case !oldDeclared:
-		rv.warn("schema version %s renames %q to %q but semconv %s does not declare %q as a metric; the rename could not be corroborated",
-			r.version, older, newer, predecessor, older)
-	case !newDeclared:
-		rv.warn("schema version %s renames %q to %q but semconv %s does not declare %q as a metric; the rename could not be corroborated",
-			r.version, older, newer, r.version, newer)
-	case !oldDef.sameMetricAs(newDef):
-		rv.warn("schema version %s renames %q to %q but semconv %s declares %q as %s/%s while semconv %s declares %q as %s/%s; treating them as different metrics and not merging their series",
-			r.version, older, newer,
-			predecessor, older, describeUnit(oldDef.unit), describeUnit(oldDef.instrument),
-			r.version, newer, describeUnit(newDef.unit), describeUnit(newDef.instrument))
+	if !declared {
+		rv.warn("schema version %s links metric %q to %q, but semconv %s does not declare %q as a metric; the rename could not be corroborated",
+			r.version, from, to, version, to)
+		return true
+	}
+	if !def.sameMetricAs(rv.anchorDef) {
+		rv.warn("queried metric %q is declared as %s/%s by semconv %s, but schema version %s links it to %q, which semconv %s declares as %s/%s; treating them as different metrics and not merging their series",
+			rv.anchorName, describeUnit(rv.anchorDef.unit), describeUnit(rv.anchorDef.instrument), rv.anchorVersion,
+			r.version, to, version, describeUnit(def.unit), describeUnit(def.instrument))
 		return false
 	}
 	return true
@@ -501,7 +542,7 @@ func (e *schemaEngine) findMatcherVariants(semconvURL, schemaURL string, origina
 		// Corroborate each rename against the semconv of the versions it
 		// connects, so a schema edge that joins two unrelated metrics sharing a
 		// surface name is reported rather than silently merged.
-		rv := newRenameValidator(&scoped, e.metricLookup(semconvURL))
+		rv := newRenameValidator(&scoped, e.metricLookup(semconvURL), sc, metricName)
 		allVariants = generateMatcherVariants(sc.version, &scoped, matchers, rv)
 		warnings = append(warnings, rv.warnings...)
 		// Map each historical attribute alias back to its anchor-version name so

--- a/storage/semconv/engine.go
+++ b/storage/semconv/engine.go
@@ -372,47 +372,68 @@ func walkVersions(
 	reverse bool,
 	rv *renameValidator,
 ) (variants [][]*labels.Matcher, applied [][]*labels.Matcher) {
-	current := matchers
-	for {
-		found := false
-		var versionsIter iter.Seq2[int, versionRenames]
-		if reverse {
-			versionsIter = slices.Backward(versions)
-		} else {
-			versionsIter = slices.All(versions)
-		}
-
-		for _, v := range versionsIter {
-			currentName, err := extractMetricName(current)
-			if err == nil && !rv.allowEdge(v, currentName) {
-				// The semconv files contradict this rename, so the walk must
-				// not chain through it either: anything reachable only via a
-				// mis-linked edge belongs to a different metric.
-				continue
-			}
-			transformed := applyVersionRenames(current, v)
-			if transformed == nil {
-				continue
+	// A queue rather than a single chain, because undoing a rename that collapsed
+	// several old names onto one yields several names at that hop and each has its
+	// own history to follow. Ordinary one-to-one edges never queue anything, so the
+	// walk is the same single chain it was for them.
+	queue := [][]*labels.Matcher{matchers}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for {
+			found := false
+			var versionsIter iter.Seq2[int, versionRenames]
+			if reverse {
+				versionsIter = slices.Backward(versions)
+			} else {
+				versionsIter = slices.All(versions)
 			}
 
-			key := matcherKey(transformed)
-			if _, exists := seen[key]; exists {
-				continue
-			}
-
-			seen[key] = struct{}{}
-			result = append(result, transformed)
-			if transformedName, nameErr := extractMetricName(transformed); nameErr == nil && currentName != "" {
-				if newer, ok := v.metricsForward[currentName]; ok && newer == transformedName {
-					applied = append(applied, transformed)
+			for _, v := range versionsIter {
+				currentName, err := extractMetricName(current)
+				if err == nil && !rv.allowEdge(v, currentName) {
+					// The semconv files contradict this rename, so the walk must
+					// not chain through it either: anything reachable only via a
+					// mis-linked edge belongs to a different metric.
+					continue
 				}
+				transformed, alternatives := applyVersionRenames(current, v)
+				if transformed == nil {
+					continue
+				}
+
+				for _, alt := range alternatives {
+					altKey := matcherKey(alt)
+					if _, exists := seen[altKey]; exists {
+						continue
+					}
+					seen[altKey] = struct{}{}
+					result = append(result, alt)
+					// Followed from here on its own, since it is a name of this
+					// metric like any other. Not added to applied: it comes from
+					// undoing a rename, so it predates the anchor.
+					queue = append(queue, alt)
+				}
+
+				key := matcherKey(transformed)
+				if _, exists := seen[key]; exists {
+					continue
+				}
+
+				seen[key] = struct{}{}
+				result = append(result, transformed)
+				if transformedName, nameErr := extractMetricName(transformed); nameErr == nil && currentName != "" {
+					if newer, ok := v.metricsForward[currentName]; ok && newer == transformedName {
+						applied = append(applied, transformed)
+					}
+				}
+				current = transformed
+				found = true
+				break
 			}
-			current = transformed
-			found = true
-			break
-		}
-		if !found {
-			break
+			if !found {
+				break
+			}
 		}
 	}
 	return result, applied
@@ -498,13 +519,23 @@ func matcherKey(matchers []*labels.Matcher) string {
 
 // applyVersionRenames applies a version's metric and attribute renames to matchers.
 // Returns nil if no renames apply. Uses lazy allocation to avoid allocating when no changes are made.
-func applyVersionRenames(matchers []*labels.Matcher, renames versionRenames) []*labels.Matcher {
-	var result []*labels.Matcher
+//
+// alternatives holds the further results of undoing a rename that collapsed several
+// old metric names onto one: that edge has one answer per old name, and every one of
+// them is a name this metric was known by, so they are all variants to query. It is
+// empty for the ordinary one-to-one edge.
+func applyVersionRenames(matchers []*labels.Matcher, renames versionRenames) (result []*labels.Matcher, alternatives [][]*labels.Matcher) {
+	metricIdx := -1
 	for i, m := range matchers {
 		var newMatcher *labels.Matcher
 		if m.Name == model.MetricNameLabel {
 			if variant, ok := renames.metrics[m.Value]; ok {
 				newMatcher = labels.MustNewMatcher(m.Type, m.Name, variant)
+				if _, forward := renames.metricsForward[m.Value]; !forward {
+					// Undoing a rename, so m.Value is the newer name and other old
+					// names may have been renamed onto it too.
+					metricIdx = i
+				}
 			}
 		} else if variant, ok := renames.attributes[m.Name]; ok {
 			newMatcher = labels.MustNewMatcher(m.Type, variant, m.Value)
@@ -520,8 +551,18 @@ func applyVersionRenames(matchers []*labels.Matcher, renames versionRenames) []*
 			result[i] = m
 		}
 	}
+	if result == nil || metricIdx < 0 {
+		return result, nil
+	}
 
-	return result
+	// The first old name is already in result (metrics holds it); the rest branch.
+	olds := renames.metricsBackward[matchers[metricIdx].Value]
+	for _, old := range olds[min(1, len(olds)):] {
+		alt := slices.Clone(result)
+		alt[metricIdx] = labels.MustNewMatcher(matchers[metricIdx].Type, model.MetricNameLabel, old)
+		alternatives = append(alternatives, alt)
+	}
+	return result, alternatives
 }
 
 type queryContext struct {

--- a/storage/semconv/engine.go
+++ b/storage/semconv/engine.go
@@ -243,11 +243,19 @@ func extractMetricName(matchers []*labels.Matcher) (string, error) {
 	return "", nil
 }
 
-// findVersionAnchorIndex returns the index of the largest version <= targetVersion.
-// The versions slice must be sorted in ascending semver order.
+// findVersionAnchorIndex returns the index of the largest version <=
+// targetVersion, or -1 when every version renames something newer than
+// targetVersion. The versions slice must be sorted in ascending semver order.
+//
+// Returning -1 rather than clamping to 0 matters, because callers split the slice
+// into versions at or before the anchor (versions[:idx+1], walked backward for
+// older names) and versions after it (versions[idx+1:], walked forward for newer
+// ones). Clamping puts the first renaming version on the backward side even though
+// it postdates the anchor, which both walks that rename in the wrong direction and
+// leaves it out of the forward chain, truncating everything that follows it.
 func findVersionAnchorIndex(versions []versionRenames, targetVersion string) int {
 	target := strings.TrimPrefix(targetVersion, "v")
-	anchorIdx := 0
+	anchorIdx := -1
 	for i, v := range versions {
 		if compareSemver(v.version, target) > 0 {
 			break
@@ -275,16 +283,34 @@ func generateMatcherVariants(version string, schema *otelSchema, matchers []*lab
 	anchorIdx := findVersionAnchorIndex(schema.versionRenames, version)
 
 	// Backward for older names.
-	variants = walkVersions(schema.versionRenames[:anchorIdx+1], matchers, seen, variants, true, rv)
+	variants, applied := walkVersions(schema.versionRenames[:anchorIdx+1], matchers, seen, variants, true, rv)
 
-	// Forward for newer names.
-	variants = walkVersions(schema.versionRenames[anchorIdx+1:], matchers, seen, variants, false, rv)
+	// Forward for newer names, from the queried name and from any name the backward
+	// walk reached by applying a rename rather than undoing one. A rename edge is
+	// stored bidirectionally, so a version at or before the anchor that renames the
+	// queried name away is walked backward yet lands on the newer name — as it must,
+	// since a user may well query a name the anchor version has already renamed. A
+	// later version then renames that name, not the queried one, and seeding the
+	// forward walk only with the queried name would cut the chain there.
+	//
+	// Names the backward walk reached by undoing a rename are deliberately not
+	// seeded. Those stopped being current before the anchor, so a later version
+	// renaming one of them is not this metric's history but a reuse of a retired
+	// name, and following it would pull an unrelated metric into the result.
+	for _, start := range append([][]*labels.Matcher{matchers}, applied...) {
+		variants, _ = walkVersions(schema.versionRenames[anchorIdx+1:], start, seen, variants, false, rv)
+	}
 
 	return variants
 }
 
 // walkVersions walks through versions applying renames, chaining results until no new variants.
 // If reverse is false, walks oldest→newest; if true, walks newest→oldest.
+//
+// applied holds the variants produced by a hop that renamed the metric in the
+// direction the schema declares it, rather than undoing a rename. Walking backward
+// those are the names the metric took at or after the version crossed, which is what
+// the forward walk has to continue from; see generateMatcherVariants.
 func walkVersions(
 	versions []versionRenames,
 	matchers []*labels.Matcher,
@@ -292,7 +318,7 @@ func walkVersions(
 	result [][]*labels.Matcher,
 	reverse bool,
 	rv *renameValidator,
-) [][]*labels.Matcher {
+) (variants [][]*labels.Matcher, applied [][]*labels.Matcher) {
 	current := matchers
 	for {
 		found := false
@@ -323,6 +349,11 @@ func walkVersions(
 
 			seen[key] = struct{}{}
 			result = append(result, transformed)
+			if transformedName, nameErr := extractMetricName(transformed); nameErr == nil && currentName != "" {
+				if newer, ok := v.metricsForward[currentName]; ok && newer == transformedName {
+					applied = append(applied, transformed)
+				}
+			}
 			current = transformed
 			found = true
 			break
@@ -331,7 +362,7 @@ func walkVersions(
 			break
 		}
 	}
-	return result
+	return result, applied
 }
 
 // buildAttributeRenameMap returns a map from each historical or forward

--- a/storage/semconv/engine.go
+++ b/storage/semconv/engine.go
@@ -490,18 +490,26 @@ func (e *schemaEngine) findMatcherVariants(semconvURL, schemaURL string, origina
 		if err != nil {
 			return nil, queryContext{}, err
 		}
+		// Narrow each version's attribute renames to those that apply to this
+		// metric, honouring apply_to_metrics, so a rename declared for one metric
+		// does not rewrite the attributes of every other metric. Done on a shallow
+		// copy to leave the cached schema untouched.
+		scoped := schema
+		scoped.versionRenames = scopedVersionRenames(
+			schema.versionRenames, metricNameAliases(schema.versionRenames, metricName))
+
 		// Corroborate each rename against the semconv of the versions it
 		// connects, so a schema edge that joins two unrelated metrics sharing a
 		// surface name is reported rather than silently merged.
-		rv := newRenameValidator(&schema, e.metricLookup(semconvURL))
-		allVariants = generateMatcherVariants(sc.version, &schema, matchers, rv)
+		rv := newRenameValidator(&scoped, e.metricLookup(semconvURL))
+		allVariants = generateMatcherVariants(sc.version, &scoped, matchers, rv)
 		warnings = append(warnings, rv.warnings...)
 		// Map each historical attribute alias back to its anchor-version name so
 		// results from older or newer eras merge under the queried version's
 		// labels instead of splitting on the renamed attribute. Recomputed per
 		// query on purpose: it is a pure function of the cached schema/semconv and
 		// costs only a few map ops, far less than the fan-out it feeds.
-		attrRenames = buildAttributeRenameMap(sc.version, &schema, sc.attributesOf(metricName))
+		attrRenames = buildAttributeRenameMap(sc.version, &scoped, sc.attributesOf(metricName))
 	}
 
 	return allVariants, queryContext{

--- a/storage/semconv/engine.go
+++ b/storage/semconv/engine.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"path"
 	"slices"
 	"strings"
 
@@ -45,6 +46,148 @@ func newSchemaEngine(registry registrySource) *schemaEngine {
 		otelSchemaCache: newStaticCache[otelSchema](),
 		semconvCache:    newStaticCache[semconv](),
 	}
+}
+
+// metricLookup resolves what a semconv version declares for a metric name.
+// declared reports whether that version declares the name as a metric at all;
+// known reports whether the version's semconv could be consulted in the first
+// place. A registry is not obliged to ship a semconv file for every version its
+// schema references (see validateRegistryFiles), so known=false means "cannot
+// verify" and must never be read as a contradiction.
+type metricLookup func(version, name string) (def metricDef, declared, known bool)
+
+// metricLookup returns a metricLookup that resolves sibling semconv versions
+// from the same registry directory as semconvURL, e.g. registry/1.0.0 for
+// version 1.0.0 when semconvURL is registry/1.1.0.
+//
+// This is where validating rename edges costs more than the current name-only
+// traversal: answering one query can now touch a semconv file per version in
+// the metric's rename chain rather than the anchor version alone. The per-call
+// memo below collapses repeat lookups within a single query, and getSemconv's
+// process-wide cache means each file is parsed at most once for the lifetime of
+// the process, so the steady-state cost is the resident size of the versions
+// actually queried rather than per-query I/O. It is still a real increase in
+// the resolver's footprint, from the anchor version to O(versions in chain).
+func (e *schemaEngine) metricLookup(semconvURL string) metricLookup {
+	dir, _ := path.Split(semconvURL)
+	// memo distinguishes "loaded" from "tried and failed" so an absent semconv
+	// is not re-fetched for every hop that consults it.
+	memo := map[string]*semconv{}
+	return func(version, name string) (metricDef, bool, bool) {
+		sc, tried := memo[version]
+		if !tried {
+			if loaded, err := e.getSemconv(dir + version); err == nil {
+				sc = &loaded
+			}
+			memo[version] = sc
+		}
+		if sc == nil {
+			return metricDef{}, false, false
+		}
+		def, declared := sc.metrics[name]
+		return def, declared, true
+	}
+}
+
+// renameValidator corroborates the schema's metric rename edges against the
+// semconv files of the versions they connect.
+//
+// The OTel schema format names metrics only by their surface name, so the rename
+// graph alone cannot distinguish a genuine rename of one metric from an edge
+// that happens to join two unrelated metrics sharing a name at different
+// versions. The semconv files can: each version states the unit and instrument
+// of the metric it declares under that name, and upstream semantic conventions
+// forbid a stable metric from changing either (policies/compatibility.rego). A
+// disagreement across an edge therefore means the two names denote different
+// metrics.
+//
+// A group's id is of no use here even though it looks like a stable identifier:
+// upstream lints it to be exactly "metric.<metric_name>"
+// (policies/yaml_schema.rego), so it is renamed in lockstep with the metric and
+// comparing ids across an edge only restates whether the name changed.
+type renameValidator struct {
+	schema *otelSchema
+	lookup metricLookup
+
+	warnings []string
+	seen     map[string]struct{}
+}
+
+func newRenameValidator(schema *otelSchema, lookup metricLookup) *renameValidator {
+	return &renameValidator{schema: schema, lookup: lookup, seen: map[string]struct{}{}}
+}
+
+func (rv *renameValidator) warn(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if _, dup := rv.seen[msg]; dup {
+		return
+	}
+	rv.seen[msg] = struct{}{}
+	rv.warnings = append(rv.warnings, msg)
+}
+
+// allowEdge reports whether the walk may traverse version r's renames starting
+// from metric name from. A nil validator allows everything, which is the
+// behaviour when no semconv is available to check against.
+//
+// It rejects an edge only on positive contradiction — both endpoints declared,
+// but with a different unit or instrument — because fusing metrics measured in
+// different units yields numerically meaningless results, which is worse than
+// returning less data. Every other suspicious case is reported and still
+// traversed: a name missing from a version's semconv is a strong hint of a
+// mis-authored edge, but a registry may legitimately ship a semconv trimmed to
+// the metrics its operator cares about, and dropping variants over that would
+// lose real series.
+func (rv *renameValidator) allowEdge(r versionRenames, from string) bool {
+	if rv == nil {
+		return true
+	}
+	older, newer, ok := r.renameDirection(from)
+	if !ok {
+		// An attribute-only hop renames no metric, so there is no metric
+		// identity to corroborate.
+		return true
+	}
+	predecessor, hasPredecessor := rv.schema.predecessorOf(r.version)
+	if !hasPredecessor {
+		// The rename is recorded at the schema's earliest version, so the
+		// version the older name belonged to is outside the schema's history.
+		return true
+	}
+
+	oldDef, oldDeclared, oldKnown := rv.lookup(predecessor, older)
+	newDef, newDeclared, newKnown := rv.lookup(r.version, newer)
+	if !oldKnown || !newKnown {
+		return true
+	}
+
+	switch {
+	case !oldDeclared && !newDeclared:
+		rv.warn("schema version %s renames %q to %q but neither name is declared as a metric by semconv %s or %s; the rename could not be corroborated",
+			r.version, older, newer, predecessor, r.version)
+	case !oldDeclared:
+		rv.warn("schema version %s renames %q to %q but semconv %s does not declare %q as a metric; the rename could not be corroborated",
+			r.version, older, newer, predecessor, older)
+	case !newDeclared:
+		rv.warn("schema version %s renames %q to %q but semconv %s does not declare %q as a metric; the rename could not be corroborated",
+			r.version, older, newer, r.version, newer)
+	case !oldDef.sameMetricAs(newDef):
+		rv.warn("schema version %s renames %q to %q but semconv %s declares %q as %s/%s while semconv %s declares %q as %s/%s; treating them as different metrics and not merging their series",
+			r.version, older, newer,
+			predecessor, older, describeUnit(oldDef.unit), describeUnit(oldDef.instrument),
+			r.version, newer, describeUnit(newDef.unit), describeUnit(newDef.instrument))
+		return false
+	}
+	return true
+}
+
+// describeUnit renders a unit or instrument for a warning message, naming an
+// undeclared one rather than rendering it as an empty string.
+func describeUnit(s string) string {
+	if s == "" {
+		return "(unspecified)"
+	}
+	return s
 }
 
 func extractMetricName(matchers []*labels.Matcher) (string, error) {
@@ -78,7 +221,10 @@ func findVersionAnchorIndex(versions []versionRenames, targetVersion string) int
 // For each version, applies both metric and attribute renames together.
 // Walks backward through versions <= version to find older name variants,
 // and forward through versions > version to find newer name variants.
-func generateMatcherVariants(version string, schema *otelSchema, matchers []*labels.Matcher) [][]*labels.Matcher {
+// rv corroborates each metric rename against the semconv files of the versions
+// it connects; a nil rv skips that check and traverses the graph on name
+// matching alone.
+func generateMatcherVariants(version string, schema *otelSchema, matchers []*labels.Matcher, rv *renameValidator) [][]*labels.Matcher {
 	if len(schema.versionRenames) == 0 {
 		return [][]*labels.Matcher{matchers}
 	}
@@ -88,10 +234,10 @@ func generateMatcherVariants(version string, schema *otelSchema, matchers []*lab
 	anchorIdx := findVersionAnchorIndex(schema.versionRenames, version)
 
 	// Backward for older names.
-	variants = walkVersions(schema.versionRenames[:anchorIdx+1], matchers, seen, variants, true)
+	variants = walkVersions(schema.versionRenames[:anchorIdx+1], matchers, seen, variants, true, rv)
 
 	// Forward for newer names.
-	variants = walkVersions(schema.versionRenames[anchorIdx+1:], matchers, seen, variants, false)
+	variants = walkVersions(schema.versionRenames[anchorIdx+1:], matchers, seen, variants, false, rv)
 
 	return variants
 }
@@ -104,6 +250,7 @@ func walkVersions(
 	seen map[string]struct{},
 	result [][]*labels.Matcher,
 	reverse bool,
+	rv *renameValidator,
 ) [][]*labels.Matcher {
 	current := matchers
 	for {
@@ -116,6 +263,13 @@ func walkVersions(
 		}
 
 		for _, v := range versionsIter {
+			currentName, err := extractMetricName(current)
+			if err == nil && !rv.allowEdge(v, currentName) {
+				// The semconv files contradict this rename, so the walk must
+				// not chain through it either: anything reachable only via a
+				// mis-linked edge belongs to a different metric.
+				continue
+			}
 			transformed := applyVersionRenames(current, v)
 			if transformed == nil {
 				continue
@@ -336,7 +490,12 @@ func (e *schemaEngine) findMatcherVariants(semconvURL, schemaURL string, origina
 		if err != nil {
 			return nil, queryContext{}, err
 		}
-		allVariants = generateMatcherVariants(sc.version, &schema, matchers)
+		// Corroborate each rename against the semconv of the versions it
+		// connects, so a schema edge that joins two unrelated metrics sharing a
+		// surface name is reported rather than silently merged.
+		rv := newRenameValidator(&schema, e.metricLookup(semconvURL))
+		allVariants = generateMatcherVariants(sc.version, &schema, matchers, rv)
+		warnings = append(warnings, rv.warnings...)
 		// Map each historical attribute alias back to its anchor-version name so
 		// results from older or newer eras merge under the queried version's
 		// labels instead of splitting on the renamed attribute. Recomputed per

--- a/storage/semconv/engine_test.go
+++ b/storage/semconv/engine_test.go
@@ -223,7 +223,9 @@ func TestFindVersionAnchorIndex(t *testing.T) {
 		{"exact match middle", "1.1.0", 1},
 		{"exact match last", "1.2.0", 2},
 		{"between versions", "1.0.5", 0},
-		{"before all versions", "0.9.0", 0},
+		// -1, not 0: no version is at or before the anchor, so the backward slice
+		// must be empty and every version must fall on the forward side.
+		{"before all versions", "0.9.0", -1},
 		{"after all versions", "2.0.0", 2},
 		{"with v prefix", "v1.1.0", 1},
 	}
@@ -235,7 +237,7 @@ func TestFindVersionAnchorIndex(t *testing.T) {
 	}
 	t.Run("empty versions", func(t *testing.T) {
 		idx := findVersionAnchorIndex([]versionRenames{}, "1.0.0")
-		require.Equal(t, 0, idx)
+		require.Equal(t, -1, idx)
 	})
 }
 
@@ -284,6 +286,88 @@ func TestGenerateMatcherVariants_AnchoredTraversal(t *testing.T) {
 		require.Contains(t, names, "metric.v3") // forward from anchor
 	})
 
+	t.Run("anchored before the first renaming version walks the whole chain forward", func(t *testing.T) {
+		// No version is at or before the anchor, so every rename must be walked
+		// forward from the queried name. Anchoring at index 0 instead put 1.1.0 on
+		// the backward side, which reached metric.v2 but left 1.2.0 with nothing to
+		// chain from, so metric.v3 was never queried.
+		schema := &otelSchema{
+			versionRenames: []versionRenames{
+				{version: "1.1.0", metrics: map[string]string{"metric.v1": "metric.v2", "metric.v2": "metric.v1"}},
+				{version: "1.2.0", metrics: map[string]string{"metric.v2": "metric.v3", "metric.v3": "metric.v2"}},
+			},
+		}
+		matchers := []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric.v1"),
+		}
+
+		result := generateMatcherVariants("1.0.0", schema, matchers, nil)
+
+		names := extractMetricNames(result)
+		require.ElementsMatch(t, []string{"metric.v1", "metric.v2", "metric.v3"}, names)
+	})
+
+	t.Run("continues forward from a name the anchor version renamed away", func(t *testing.T) {
+		// metric.v1 is not the name this metric has at 1.1.0 — 1.1.0 is the version
+		// that renamed it — so the backward walk crosses that rename and lands on
+		// metric.v2. The 1.2.0 rename is of metric.v2, so the forward walk has to
+		// start from what the backward walk found rather than from the queried name.
+		schema := &otelSchema{
+			versionRenames: []versionRenames{
+				{
+					version:        "1.1.0",
+					metrics:        map[string]string{"metric.v1": "metric.v2", "metric.v2": "metric.v1"},
+					metricsForward: map[string]string{"metric.v1": "metric.v2"},
+				},
+				{
+					version:        "1.2.0",
+					metrics:        map[string]string{"metric.v2": "metric.v3", "metric.v3": "metric.v2"},
+					metricsForward: map[string]string{"metric.v2": "metric.v3"},
+				},
+			},
+		}
+		matchers := []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric.v1"),
+		}
+
+		result := generateMatcherVariants("1.1.0", schema, matchers, nil)
+
+		names := extractMetricNames(result)
+		require.ElementsMatch(t, []string{"metric.v1", "metric.v2", "metric.v3"}, names)
+	})
+
+	t.Run("does not follow a post-anchor rename of a retired name", func(t *testing.T) {
+		// 1.1.0 renames metric.v1 to metric.v2, and 1.2.0 renames metric.v1 again —
+		// a name retired at 1.1.0 being reused by an unrelated metric. Anchored at
+		// 1.1.0, the backward walk reaches metric.v1 by undoing the first rename, so
+		// it must not seed the forward walk: metric.v1 stopped being this metric's
+		// name at 1.1.0, and what 1.2.0 does with the name afterwards is not its
+		// history. rv is nil here, so nothing but the walk itself excludes it.
+		schema := &otelSchema{
+			versionRenames: []versionRenames{
+				{
+					version:        "1.1.0",
+					metrics:        map[string]string{"metric.v1": "metric.v2", "metric.v2": "metric.v1"},
+					metricsForward: map[string]string{"metric.v1": "metric.v2"},
+				},
+				{
+					version:        "1.2.0",
+					metrics:        map[string]string{"metric.v1": "other.metric", "other.metric": "metric.v1"},
+					metricsForward: map[string]string{"metric.v1": "other.metric"},
+				},
+			},
+		}
+		matchers := []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric.v2"),
+		}
+
+		result := generateMatcherVariants("1.1.0", schema, matchers, nil)
+
+		names := extractMetricNames(result)
+		require.ElementsMatch(t, []string{"metric.v2", "metric.v1"}, names)
+		require.NotContains(t, names, "other.metric")
+	})
+
 	t.Run("handles version with v prefix", func(t *testing.T) {
 		schema := &otelSchema{
 			versionRenames: []versionRenames{
@@ -325,6 +409,22 @@ func TestBuildAttributeRenameMap(t *testing.T) {
 		}
 		got := buildAttributeRenameMap("1.1.0", schema, []string{"attr.v3"})
 		require.Equal(t, map[string]string{"attr.v2": "attr.v3", "attr.v1": "attr.v3"}, got)
+	})
+
+	t.Run("anchored before the first renaming version follows the chain forward", func(t *testing.T) {
+		// Every version postdates the anchor, so all of them belong to the forward
+		// walk. Putting the earliest of them on the backward side instead left the
+		// forward walk starting from attr.v1, which 1.2.0 does not rename, so
+		// attr.v3 never mapped back to the anchor name and a series carrying it
+		// would have split off on its own.
+		schema := &otelSchema{
+			versionRenames: []versionRenames{
+				{version: "1.1.0", attributes: map[string]string{"attr.v1": "attr.v2", "attr.v2": "attr.v1"}},
+				{version: "1.2.0", attributes: map[string]string{"attr.v2": "attr.v3", "attr.v3": "attr.v2"}},
+			},
+		}
+		got := buildAttributeRenameMap("1.0.0", schema, []string{"attr.v1"})
+		require.Equal(t, map[string]string{"attr.v2": "attr.v1", "attr.v3": "attr.v1"}, got)
 	})
 
 	t.Run("no schema renames returns nil", func(t *testing.T) {

--- a/storage/semconv/engine_test.go
+++ b/storage/semconv/engine_test.go
@@ -14,6 +14,7 @@
 package semconv
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -438,5 +439,90 @@ func TestBuildAttributeRenameMap(t *testing.T) {
 			},
 		}
 		require.Nil(t, buildAttributeRenameMap("1.1.0", schema, nil))
+	})
+}
+
+// TestGenerateMatcherVariants_ManyToOneRename covers a version that renames several
+// old metric names onto one. Undoing that edge has an answer per old name, and each
+// is a name the metric was known by, so all of them have to be queried. Holding the
+// reverse direction in a one-to-one map could only keep one, chosen by Go's map
+// iteration order, so the set of historical names a query covered could differ
+// between processes.
+func TestGenerateMatcherVariants_ManyToOneRename(t *testing.T) {
+	t.Run("follows every old name renamed onto the queried one", func(t *testing.T) {
+		schema, err := loadOTelSchema([]byte(`file_format: 1.1.0
+schema_url: https://example.com/schemas/1.1.0
+versions:
+  1.0.0:
+  1.1.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            metric.b: metric.merged
+            metric.a: metric.merged
+`))
+		require.NoError(t, err)
+
+		matchers := []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric.merged"),
+		}
+		result := generateMatcherVariants("1.1.0", &schema, matchers, nil)
+
+		require.ElementsMatch(t,
+			[]string{"metric.merged", "metric.a", "metric.b"},
+			extractMetricNames(result))
+	})
+
+	t.Run("follows each old name's own earlier renames", func(t *testing.T) {
+		// metric.b is reached only by branching at the collapsed edge, and it has a
+		// rename of its own before that, so the branch has to be walked on and not
+		// merely recorded.
+		schema, err := loadOTelSchema([]byte(`file_format: 1.1.0
+schema_url: https://example.com/schemas/1.1.0
+versions:
+  1.0.0:
+  1.1.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            metric.b.older: metric.b
+  1.2.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            metric.a: metric.merged
+            metric.b: metric.merged
+`))
+		require.NoError(t, err)
+
+		matchers := []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric.merged"),
+		}
+		result := generateMatcherVariants("1.2.0", &schema, matchers, nil)
+
+		require.ElementsMatch(t,
+			[]string{"metric.merged", "metric.a", "metric.b", "metric.b.older"},
+			extractMetricNames(result))
+	})
+
+	// The real thing: semconv 1.38.0 merges two spellings of the replication
+	// controller metrics onto one name. Both spellings must be queried, in an order
+	// that does not vary between processes.
+	t.Run("upstream schema collapses two spellings", func(t *testing.T) {
+		b, err := os.ReadFile("./testdata/upstream/schema-1.44.0.yaml")
+		require.NoError(t, err)
+		schema, err := loadOTelSchema(b)
+		require.NoError(t, err)
+
+		matchers := []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "k8s.replicationcontroller.pod.available"),
+		}
+		result := generateMatcherVariants("1.44.0", &schema, matchers, nil)
+
+		require.Equal(t, []string{
+			"k8s.replicationcontroller.pod.available",
+			"k8s.replicationcontroller.available_pods",
+			"k8s.replication_controller.available_pods",
+		}, extractMetricNames(result))
 	})
 }

--- a/storage/semconv/engine_test.go
+++ b/storage/semconv/engine_test.go
@@ -48,7 +48,7 @@ func TestGenerateMatcherVariants(t *testing.T) {
 			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric.v2"),
 		}
 
-		result := generateMatcherVariants("1.0.0", schema, matchers)
+		result := generateMatcherVariants("1.0.0", schema, matchers, nil)
 
 		// Should have original + 1 version variant.
 		require.Len(t, result, 2)
@@ -72,7 +72,7 @@ func TestGenerateMatcherVariants(t *testing.T) {
 			labels.MustNewMatcher(labels.MatchEqual, "attr.new", "value"),
 		}
 
-		result := generateMatcherVariants("1.0.0", schema, matchers)
+		result := generateMatcherVariants("1.0.0", schema, matchers, nil)
 
 		// Should have original + 1 version variant (both metric AND attr renamed together).
 		require.Len(t, result, 2)
@@ -120,7 +120,7 @@ func TestGenerateMatcherVariants(t *testing.T) {
 			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric.v3"),
 		}
 
-		result := generateMatcherVariants("1.1.0", schema, matchers)
+		result := generateMatcherVariants("1.1.0", schema, matchers, nil)
 
 		// Anchored at 1.1.0, backward walk resolves: v3 → v2 (via 1.1.0) → v1 (via 1.0.0).
 		require.Len(t, result, 3)
@@ -150,7 +150,7 @@ func TestGenerateMatcherVariants(t *testing.T) {
 			labels.MustNewMatcher(labels.MatchEqual, "attr.v3", "value"),
 		}
 
-		result := generateMatcherVariants("1.1.0", schema, matchers)
+		result := generateMatcherVariants("1.1.0", schema, matchers, nil)
 
 		// Anchored at 1.1.0, should have 3 variants with metric+attr paired correctly.
 		require.Len(t, result, 3)
@@ -188,7 +188,7 @@ func TestGenerateMatcherVariants(t *testing.T) {
 			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "my.metric"),
 		}
 
-		result := generateMatcherVariants("1.0.0", schema, matchers)
+		result := generateMatcherVariants("1.0.0", schema, matchers, nil)
 
 		require.Len(t, result, 1)
 		require.Equal(t, matchers, result[0])
@@ -254,7 +254,7 @@ func TestGenerateMatcherVariants_AnchoredTraversal(t *testing.T) {
 		}
 
 		// Anchored at 1.1.0: backward walks [1.0.0, 1.1.0], forward walks [1.1.0, 1.2.0].
-		result := generateMatcherVariants("1.1.0", schema, matchers)
+		result := generateMatcherVariants("1.1.0", schema, matchers, nil)
 
 		require.Len(t, result, 4) // v1, v2, v3, v4
 		names := extractMetricNames(result)
@@ -276,7 +276,7 @@ func TestGenerateMatcherVariants_AnchoredTraversal(t *testing.T) {
 		}
 
 		// Anchored at 1.0.0: backward walks [1.0.0], forward walks [1.0.0, 1.1.0].
-		result := generateMatcherVariants("1.0.0", schema, matchers)
+		result := generateMatcherVariants("1.0.0", schema, matchers, nil)
 
 		names := extractMetricNames(result)
 		require.Contains(t, names, "metric.v1") // backward from anchor
@@ -294,7 +294,7 @@ func TestGenerateMatcherVariants_AnchoredTraversal(t *testing.T) {
 			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric.new"),
 		}
 
-		result := generateMatcherVariants("v1.0.0", schema, matchers)
+		result := generateMatcherVariants("v1.0.0", schema, matchers, nil)
 
 		require.Len(t, result, 2)
 		names := extractMetricNames(result)

--- a/storage/semconv/otel_schema.go
+++ b/storage/semconv/otel_schema.go
@@ -138,8 +138,31 @@ type otelSchema struct {
 	Versions   map[string]otelSchemaVersion `yaml:"versions"`
 
 	// versionRenames holds per-version renames for generating matcher variants
-	// (populated by loadOTelSchema).
+	// (populated by loadOTelSchema). Versions that rename nothing are omitted.
 	versionRenames []versionRenames
+
+	// allVersions lists every version the schema declares, in ascending semver
+	// order, including versions that rename nothing (populated by
+	// loadOTelSchema). Unlike versionRenames it is a complete history, which is
+	// what identifying the version a pre-rename name belongs to requires: a
+	// rename recorded under version V takes effect at V, so the old name is the
+	// current one at V's immediate predecessor here, which may well be a version
+	// that renames nothing.
+	allVersions []string
+}
+
+// predecessorOf returns the version immediately before v in the schema's version
+// history, and false if v is the earliest version or is not in the history.
+func (s *otelSchema) predecessorOf(v string) (string, bool) {
+	for i, have := range s.allVersions {
+		if have == v {
+			if i == 0 {
+				return "", false
+			}
+			return s.allVersions[i-1], true
+		}
+	}
+	return "", false
 }
 
 // versionRenames holds bidirectional rename mappings from a single schema version.
@@ -148,14 +171,36 @@ type versionRenames struct {
 	version    string            // e.g., "1.1.0"
 	metrics    map[string]string // metric name → its variant (bidirectional)
 	attributes map[string]string // attribute name → its variant (bidirectional)
+
+	// metricsForward holds metric renames in the direction the schema declares
+	// them, old name → new name. metrics is deliberately bidirectional so a walk
+	// can traverse an edge from either end, but that loses which end is the older
+	// name, and validating an edge against the semconv files requires knowing
+	// which version each name belongs to.
+	metricsForward map[string]string
+}
+
+// renameDirection reports the older and newer name of the metric rename edge
+// connecting from to its variant at this version, and false if from is not
+// renamed here.
+func (r versionRenames) renameDirection(from string) (older, newer string, ok bool) {
+	to, ok := r.metrics[from]
+	if !ok {
+		return "", "", false
+	}
+	if _, forward := r.metricsForward[from]; forward {
+		return from, to, true
+	}
+	return to, from, true
 }
 
 // collectVersionRenames extracts bidirectional rename mappings from a schema version.
 func collectVersionRenames(versionStr string, version otelSchemaVersion) *versionRenames {
 	renames := &versionRenames{
-		version:    versionStr,
-		metrics:    make(map[string]string),
-		attributes: make(map[string]string),
+		version:        versionStr,
+		metrics:        make(map[string]string),
+		attributes:     make(map[string]string),
+		metricsForward: make(map[string]string),
 	}
 
 	// Collect attribute renames from "all" section.
@@ -177,6 +222,7 @@ func collectVersionRenames(versionStr string, version otelSchemaVersion) *versio
 				for oldName, newName := range change.RenameMetrics.NameMap {
 					renames.metrics[oldName] = newName
 					renames.metrics[newName] = oldName
+					renames.metricsForward[oldName] = newName
 				}
 			}
 			if change.RenameAttributes != nil {
@@ -288,11 +334,13 @@ func loadOTelSchema(b []byte) (otelSchema, error) {
 	}
 
 	s.versionRenames = make([]versionRenames, 0, len(s.Versions))
+	s.allVersions = make([]string, 0, len(s.Versions))
 
 	for versionStr, version := range s.Versions {
 		if err := validateSemver(versionStr); err != nil {
 			return otelSchema{}, err
 		}
+		s.allVersions = append(s.allVersions, versionStr)
 		if renames := collectVersionRenames(versionStr, version); renames != nil {
 			s.versionRenames = append(s.versionRenames, *renames)
 		}
@@ -301,6 +349,7 @@ func loadOTelSchema(b []byte) (otelSchema, error) {
 	slices.SortFunc(s.versionRenames, func(a, b versionRenames) int {
 		return compareSemver(a.version, b.version)
 	})
+	slices.SortFunc(s.allVersions, compareSemver)
 
 	return s, nil
 }

--- a/storage/semconv/otel_schema.go
+++ b/storage/semconv/otel_schema.go
@@ -165,6 +165,43 @@ func (s *otelSchema) predecessorOf(v string) (string, bool) {
 	return "", false
 }
 
+// eraVersionsOf returns the versions at which name is the metric's current name,
+// as far as the schema's rename edges say: the version that introduced the name,
+// and the version before the one that renamed it away. Both lie inside an era in
+// which the name is current, so either can be asked what the name meant then.
+//
+// More than one is returned only when the schema renames the name away and later
+// introduces it again — a retired name reused by another metric — in which case
+// which era a caller means is genuinely ambiguous and the callers here decline to
+// guess. Versions are returned in ascending order and are never repeated.
+func (s *otelSchema) eraVersionsOf(name string) []string {
+	var out []string
+	for _, v := range s.versionRenames {
+		older, newer, ok := v.renameDirection(name)
+		if !ok {
+			continue
+		}
+		var era string
+		switch name {
+		case older:
+			// Renamed away here, so current up to the version before this one.
+			predecessor, hasPredecessor := s.predecessorOf(v.version)
+			if !hasPredecessor {
+				continue
+			}
+			era = predecessor
+		case newer:
+			// Introduced here, so current from this version on.
+			era = v.version
+		}
+		if era != "" && !slices.Contains(out, era) {
+			out = append(out, era)
+		}
+	}
+	slices.SortFunc(out, compareSemver)
+	return out
+}
+
 // versionRenames holds bidirectional rename mappings from a single schema version.
 // When a version renames a→b, both directions are stored for lookup.
 type versionRenames struct {

--- a/storage/semconv/otel_schema.go
+++ b/storage/semconv/otel_schema.go
@@ -233,7 +233,7 @@ func collectVersionRenames(versionStr string, version otelSchemaVersion) *versio
 			if change.RenameMetrics == nil {
 				continue
 			}
-			for oldName, newName := range change.RenameMetrics.NameMap {
+			for oldName, newName := range change.RenameMetrics {
 				renames.metrics[oldName] = newName
 				renames.metrics[newName] = oldName
 				renames.metricsForward[oldName] = newName
@@ -374,16 +374,24 @@ type otelSchemaSection struct {
 
 type otelSchemaChange struct {
 	RenameAttributes *otelRenameAttributes `yaml:"rename_attributes,omitempty"`
-	RenameMetrics    *otelRenameMetrics    `yaml:"rename_metrics,omitempty"`
+
+	// RenameMetrics maps each old metric name to its new name directly, with no
+	// intervening key. This is asymmetric with RenameAttributes, which nests its
+	// mapping under attribute_map, but it is what the file format specifies:
+	//
+	//	metrics:
+	//	  changes:
+	//	    - rename_metrics:
+	//	        http.server.duration: http.server.request.duration
+	//
+	// See the rename_metrics transformation in
+	// https://opentelemetry.io/docs/specs/otel/schemas/file_format_v1.1.0/.
+	RenameMetrics map[string]string `yaml:"rename_metrics,omitempty"`
 }
 
 type otelRenameAttributes struct {
 	AttributeMap   map[string]string `yaml:"attribute_map,omitempty"`
 	ApplyToMetrics []string          `yaml:"apply_to_metrics,omitempty"`
-}
-
-type otelRenameMetrics struct {
-	NameMap map[string]string `yaml:"name_map,omitempty"`
 }
 
 // staticCache is a generic, goroutine-safe cache keyed by URL for static

--- a/storage/semconv/otel_schema.go
+++ b/storage/semconv/otel_schema.go
@@ -16,6 +16,7 @@ package semconv
 import (
 	"embed"
 	"fmt"
+	"maps"
 	"path"
 	"slices"
 	"strconv"
@@ -72,10 +73,46 @@ type semconv struct {
 
 	version string
 
-	// attributesPerMetric lists, per metric name, the attributes the metric
-	// declares at this semconv version (populated by loadSemconv). It seeds
-	// attribute-rename normalisation; see buildAttributeRenameMap.
-	attributesPerMetric map[string][]string
+	// metrics indexes this version's metric groups by their metric_name
+	// (populated by loadSemconv). It answers both "is this name a metric at this
+	// version" and "what does it declare", which is what validating a schema
+	// rename edge needs; see validateMetricRename.
+	metrics map[string]metricDef
+
+	// ambiguousMetrics lists metric names declared by more than one group at
+	// this version, sorted. Such a name has no single definition, so anything
+	// resolved through it is unreliable and is reported to the caller rather
+	// than silently resolved to whichever group happened to be parsed last.
+	ambiguousMetrics []string
+}
+
+// metricDef is the part of a semconv metric group that describes what the metric
+// *is*, as opposed to what it is currently called. unit and instrument are the
+// fields upstream semantic conventions forbid a stable metric from changing (see
+// policies/compatibility.rego in open-telemetry/semantic-conventions), which is
+// what makes them usable as a cross-version identity check.
+//
+// Note that a group's id is deliberately not part of this: upstream lints id to
+// be exactly "metric.<metric_name>" (policies/yaml_schema.rego), so it is a pure
+// function of the surface name and changes in lockstep with every rename. It
+// therefore carries no identity information a rename edge does not already have.
+type metricDef struct {
+	unit       string
+	instrument string
+	attributes []string
+}
+
+// sameMetricAs reports whether d and other are compatible enough to be the same
+// semantic metric across a rename. A differing unit or instrument means two
+// distinct metrics that merely share a surface name at different versions.
+func (d metricDef) sameMetricAs(other metricDef) bool {
+	return d.unit == other.unit && d.instrument == other.instrument
+}
+
+// attributesOf returns the attributes the named metric declares at this semconv
+// version, or nil if the name is not a metric here.
+func (s semconv) attributesOf(name string) []string {
+	return s.metrics[name].attributes
 }
 
 // otelSchema represents an OpenTelemetry schema file.
@@ -162,6 +199,8 @@ type semconvGroup struct {
 	ID         string             `yaml:"id"`
 	Type       string             `yaml:"type"`        // "metric", "attribute", "span", etc.
 	MetricName string             `yaml:"metric_name"` // Only for type="metric"
+	Unit       string             `yaml:"unit"`        // Only for type="metric", e.g. "s", "By"
+	Instrument string             `yaml:"instrument"`  // Only for type="metric", e.g. "histogram", "counter"
 	Attributes []semconvAttribute `yaml:"attributes,omitempty"`
 }
 
@@ -313,16 +352,38 @@ func loadSemconv(b []byte, version string) (semconv, error) {
 		return semconv{}, fmt.Errorf("unmarshal: %w", err)
 	}
 	s.version = version
-	s.attributesPerMetric = make(map[string][]string)
+	s.metrics = make(map[string]metricDef)
+	// A metric name declared by two groups has no single definition. Keeping the
+	// first declaration rather than the last makes the outcome depend on file
+	// order in one direction only, but either choice is arbitrary, so the name is
+	// also recorded as ambiguous and reported to the querier as a warning.
+	var ambiguous map[string]struct{}
 	for _, group := range s.Groups {
-		if group.Type != "metric" || group.MetricName == "" || len(group.Attributes) == 0 {
+		if group.Type != "metric" || group.MetricName == "" {
 			continue
 		}
-		attrs := make([]string, 0, len(group.Attributes))
-		for _, attr := range group.Attributes {
-			attrs = append(attrs, attr.Ref)
+		if _, dup := s.metrics[group.MetricName]; dup {
+			if ambiguous == nil {
+				ambiguous = map[string]struct{}{}
+			}
+			ambiguous[group.MetricName] = struct{}{}
+			continue
 		}
-		s.attributesPerMetric[group.MetricName] = attrs
+		var attrs []string
+		if len(group.Attributes) > 0 {
+			attrs = make([]string, 0, len(group.Attributes))
+			for _, attr := range group.Attributes {
+				attrs = append(attrs, attr.Ref)
+			}
+		}
+		s.metrics[group.MetricName] = metricDef{
+			unit:       group.Unit,
+			instrument: group.Instrument,
+			attributes: attrs,
+		}
+	}
+	if len(ambiguous) > 0 {
+		s.ambiguousMetrics = slices.Sorted(maps.Keys(ambiguous))
 	}
 	return s, nil
 }

--- a/storage/semconv/otel_schema.go
+++ b/storage/semconv/otel_schema.go
@@ -168,9 +168,19 @@ func (s *otelSchema) predecessorOf(v string) (string, bool) {
 // versionRenames holds bidirectional rename mappings from a single schema version.
 // When a version renames a→b, both directions are stored for lookup.
 type versionRenames struct {
-	version    string            // e.g., "1.1.0"
-	metrics    map[string]string // metric name → its variant (bidirectional)
-	attributes map[string]string // attribute name → its variant (bidirectional)
+	version string            // e.g., "1.1.0"
+	metrics map[string]string // metric name → its variant (bidirectional)
+
+	// attributes holds the attribute renames that apply to every metric: those
+	// declared in the "all" section, and metrics-section renames that name no
+	// apply_to_metrics. Bidirectional, like metrics.
+	attributes map[string]string
+
+	// attributesPerMetric holds attribute renames restricted by apply_to_metrics,
+	// keyed by each metric name the change is scoped to. A metric's effective
+	// renames are attributes plus the entries for the names it is known by; see
+	// scopedVersionRenames.
+	attributesPerMetric map[string]map[string]string
 
 	// metricsForward holds metric renames in the direction the schema declares
 	// them, old name → new name. metrics is deliberately bidirectional so a walk
@@ -215,29 +225,127 @@ func collectVersionRenames(versionStr string, version otelSchemaVersion) *versio
 		}
 	}
 
-	// Collect metric and attribute renames from "metrics" section.
+	// Collect metric renames from the "metrics" section first, so that scoping an
+	// attribute rename below can also register it against the other name the
+	// metric is called at this version.
 	if version.Metrics != nil {
 		for _, change := range version.Metrics.Changes {
-			if change.RenameMetrics != nil {
-				for oldName, newName := range change.RenameMetrics.NameMap {
-					renames.metrics[oldName] = newName
-					renames.metrics[newName] = oldName
-					renames.metricsForward[oldName] = newName
-				}
+			if change.RenameMetrics == nil {
+				continue
 			}
-			if change.RenameAttributes != nil {
+			for oldName, newName := range change.RenameMetrics.NameMap {
+				renames.metrics[oldName] = newName
+				renames.metrics[newName] = oldName
+				renames.metricsForward[oldName] = newName
+			}
+		}
+
+		// Collect attribute renames from the "metrics" section, restricted to the
+		// metrics named by apply_to_metrics where it is given.
+		for _, change := range version.Metrics.Changes {
+			if change.RenameAttributes == nil {
+				continue
+			}
+			if len(change.RenameAttributes.ApplyToMetrics) == 0 {
 				for oldName, newName := range change.RenameAttributes.AttributeMap {
 					renames.attributes[oldName] = newName
 					renames.attributes[newName] = oldName
+				}
+				continue
+			}
+			for _, metric := range change.RenameAttributes.ApplyToMetrics {
+				// apply_to_metrics names the metric as of this version. The same
+				// metric is known by its pre-rename name on the other side of a
+				// rename recorded here, so scope the change to both.
+				for _, name := range []string{metric, renames.metrics[metric]} {
+					if name == "" {
+						continue
+					}
+					if renames.attributesPerMetric == nil {
+						renames.attributesPerMetric = map[string]map[string]string{}
+					}
+					scoped := renames.attributesPerMetric[name]
+					if scoped == nil {
+						scoped = map[string]string{}
+						renames.attributesPerMetric[name] = scoped
+					}
+					for oldName, newName := range change.RenameAttributes.AttributeMap {
+						scoped[oldName] = newName
+						scoped[newName] = oldName
+					}
 				}
 			}
 		}
 	}
 
-	if len(renames.metrics) == 0 && len(renames.attributes) == 0 {
+	if len(renames.metrics) == 0 && len(renames.attributes) == 0 && len(renames.attributesPerMetric) == 0 {
 		return nil
 	}
 	return renames
+}
+
+// scopedVersionRenames returns versions with each version's attribute renames
+// narrowed to those that apply to a metric known by any of names: the version's
+// unscoped renames plus the entries apply_to_metrics scoped to it. Positions are
+// preserved so version indices remain comparable.
+//
+// Narrowing up front means the walk and the attribute-rename map can keep
+// treating a version's attribute map as flat, with no scoping logic of their own.
+func scopedVersionRenames(versions []versionRenames, names map[string]struct{}) []versionRenames {
+	anyScoped := false
+	for _, v := range versions {
+		if len(v.attributesPerMetric) > 0 {
+			anyScoped = true
+			break
+		}
+	}
+	if !anyScoped {
+		// No version restricts an attribute rename, so every version's map
+		// already is the effective one.
+		return versions
+	}
+
+	out := make([]versionRenames, len(versions))
+	for i, v := range versions {
+		out[i] = v
+		if len(v.attributesPerMetric) == 0 {
+			continue
+		}
+		effective := maps.Clone(v.attributes)
+		if effective == nil {
+			effective = map[string]string{}
+		}
+		for name := range names {
+			maps.Copy(effective, v.attributesPerMetric[name])
+		}
+		out[i].attributes = effective
+	}
+	return out
+}
+
+// metricNameAliases returns every name the metric called name is known by at some
+// version of the schema, following metric rename edges from name in both
+// directions. It is what scoping needs, because apply_to_metrics names a metric
+// as of one version while the walk visits it under all of its names.
+func metricNameAliases(versions []versionRenames, name string) map[string]struct{} {
+	aliases := map[string]struct{}{name: {}}
+	for grew := true; grew; {
+		grew = false
+		for _, v := range versions {
+			for from := range aliases {
+				to, ok := v.metrics[from]
+				if !ok {
+					continue
+				}
+				if _, have := aliases[to]; have {
+					continue
+				}
+				aliases[to] = struct{}{}
+				grew = true
+			}
+		}
+	}
+	return aliases
 }
 
 // semconvGroup represents a semantic conventions group definition.

--- a/storage/semconv/otel_schema.go
+++ b/storage/semconv/otel_schema.go
@@ -225,6 +225,14 @@ type versionRenames struct {
 	// name, and validating an edge against the semconv files requires knowing
 	// which version each name belongs to.
 	metricsForward map[string]string
+
+	// metricsBackward holds the reverse direction as one-to-many, new name → every
+	// old name renamed onto it, sorted. A version may collapse several old names
+	// onto one, which the schema format allows and real schemas do (semconv 1.38.0
+	// merges two spellings of k8s.replicationcontroller.pod.available). Walking such
+	// an edge backward has more than one answer, so metrics can only hold one of
+	// them and the walk consults this to branch; see applyVersionRenames.
+	metricsBackward map[string][]string
 }
 
 // renameDirection reports the older and newer name of the metric rename edge
@@ -272,9 +280,22 @@ func collectVersionRenames(versionStr string, version otelSchemaVersion) *versio
 			}
 			for oldName, newName := range change.RenameMetrics {
 				renames.metrics[oldName] = newName
-				renames.metrics[newName] = oldName
 				renames.metricsForward[oldName] = newName
+				if renames.metricsBackward == nil {
+					renames.metricsBackward = map[string][]string{}
+				}
+				renames.metricsBackward[newName] = append(renames.metricsBackward[newName], oldName)
 			}
+		}
+		// Sorted, and the reverse entries in metrics written from the sorted result,
+		// so a version collapsing several old names onto one resolves the same way
+		// in every process. Reading them straight out of the YAML map left which old
+		// name metrics reported dependent on Go's map iteration order, so a query
+		// could return a different set of historical names after a restart.
+		for newName, oldNames := range renames.metricsBackward {
+			slices.Sort(oldNames)
+			renames.metricsBackward[newName] = slices.Compact(oldNames)
+			renames.metrics[newName] = renames.metricsBackward[newName][0]
 		}
 
 		// Collect attribute renames from the "metrics" section, restricted to the

--- a/storage/semconv/otel_schema_test.go
+++ b/storage/semconv/otel_schema_test.go
@@ -169,6 +169,30 @@ func TestFetchSemconv(t *testing.T) {
 	})
 }
 
+func TestPredecessorOf(t *testing.T) {
+	// A version that renames nothing is dropped from versionRenames but must
+	// still count as a predecessor, since a pre-rename metric name can perfectly
+	// well belong to a version that renamed nothing itself.
+	schema := loadOTelSchemaFile(t, "./testdata/otel_with_chained_renames.yaml")
+	require.Equal(t, []string{"1.0.0", "1.1.0"}, schema.allVersions)
+
+	tests := []struct {
+		version  string
+		expected string
+		found    bool
+	}{
+		{"1.1.0", "1.0.0", true},
+		{"1.0.0", "", false}, // Earliest version has no predecessor.
+		{"9.9.9", "", false}, // Not in the schema's history.
+		{"", "", false},
+	}
+	for _, tc := range tests {
+		got, found := schema.predecessorOf(tc.version)
+		require.Equal(t, tc.found, found, "predecessorOf(%q)", tc.version)
+		require.Equal(t, tc.expected, got, "predecessorOf(%q)", tc.version)
+	}
+}
+
 func TestLoadSemconv(t *testing.T) {
 	t.Run("indexes metric groups with unit and instrument", func(t *testing.T) {
 		sc, err := loadSemconv([]byte(`

--- a/storage/semconv/otel_schema_test.go
+++ b/storage/semconv/otel_schema_test.go
@@ -169,6 +169,73 @@ func TestFetchSemconv(t *testing.T) {
 	})
 }
 
+func TestLoadSemconv(t *testing.T) {
+	t.Run("indexes metric groups with unit and instrument", func(t *testing.T) {
+		sc, err := loadSemconv([]byte(`
+groups:
+  - id: metric.http.server.request.duration
+    type: metric
+    metric_name: http.server.request.duration
+    unit: s
+    instrument: histogram
+    attributes:
+      - ref: http.request.method
+`), "1.0.0")
+		require.NoError(t, err)
+		require.Equal(t, metricDef{
+			unit:       "s",
+			instrument: "histogram",
+			attributes: []string{"http.request.method"},
+		}, sc.metrics["http.server.request.duration"])
+		require.Empty(t, sc.ambiguousMetrics)
+	})
+
+	t.Run("indexes a metric group that declares no attributes", func(t *testing.T) {
+		// Such a group is still a metric, so it must be visible to the
+		// existence check that validates rename edges, even though it
+		// contributes nothing to attribute-rename normalisation.
+		sc, err := loadSemconv([]byte(`
+groups:
+  - id: metric.queue.depth
+    type: metric
+    metric_name: queue.depth
+    unit: "{item}"
+    instrument: updowncounter
+`), "1.0.0")
+		require.NoError(t, err)
+		require.Contains(t, sc.metrics, "queue.depth")
+		require.Empty(t, sc.attributesOf("queue.depth"))
+	})
+
+	t.Run("reports a metric name declared by more than one group", func(t *testing.T) {
+		// Two groups, same surface name, different semantics. Previously the
+		// second silently overwrote the first, so the queue.depth attributes
+		// were dropped and its unit was reported as the HTTP metric's.
+		sc, err := loadSemconv([]byte(`
+groups:
+  - id: metric.shared.name
+    type: metric
+    metric_name: shared.name
+    unit: s
+    instrument: histogram
+    attributes:
+      - ref: http.request.method
+  - id: metric.shared.name.other
+    type: metric
+    metric_name: shared.name
+    unit: "{item}"
+    instrument: updowncounter
+    attributes:
+      - ref: queue.name
+`), "1.0.0")
+		require.NoError(t, err)
+		require.Equal(t, []string{"shared.name"}, sc.ambiguousMetrics)
+		// Resolution is deterministic (first declaration wins) rather than
+		// dependent on which group happened to be parsed last.
+		require.Equal(t, []string{"http.request.method"}, sc.attributesOf("shared.name"))
+	})
+}
+
 func TestTransformOTelSchemaLabels(t *testing.T) {
 	t.Run("transforms metric and label names", func(t *testing.T) {
 		lbls := labels.FromStrings(

--- a/storage/semconv/otel_schema_test.go
+++ b/storage/semconv/otel_schema_test.go
@@ -362,3 +362,33 @@ func TestReadRegistryFile(t *testing.T) {
 		}
 	})
 }
+
+func TestEraVersionsOf(t *testing.T) {
+	// old.name is current up to 1.0.0, new.name from 1.1.0 on, and 1.2.0 hands
+	// old.name to an unrelated metric, giving that name a second era.
+	schema, err := loadOTelSchema([]byte(`file_format: 1.1.0
+schema_url: https://example.com/schemas/1.1.0
+versions:
+  1.0.0:
+  1.1.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            old.name: new.name
+  1.2.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            other.name: old.name
+`))
+	require.NoError(t, err)
+
+	// Retired at 1.1.0, so current up to 1.0.0; reintroduced at 1.2.0.
+	require.Equal(t, []string{"1.0.0", "1.2.0"}, schema.eraVersionsOf("old.name"))
+	// Introduced at 1.1.0 and never renamed away.
+	require.Equal(t, []string{"1.1.0"}, schema.eraVersionsOf("new.name"))
+	// Renamed away at 1.2.0, so current up to 1.1.0.
+	require.Equal(t, []string{"1.1.0"}, schema.eraVersionsOf("other.name"))
+	// Not mentioned by any rename, so the schema says nothing about its era.
+	require.Empty(t, schema.eraVersionsOf("unrelated.name"))
+}

--- a/storage/semconv/otel_schema_test.go
+++ b/storage/semconv/otel_schema_test.go
@@ -392,3 +392,34 @@ versions:
 	// Not mentioned by any rename, so the schema says nothing about its era.
 	require.Empty(t, schema.eraVersionsOf("unrelated.name"))
 }
+
+// TestUpstreamSemconvAttributes pins how the real semconv files' metric attributes
+// parse, against the unmodified v1.44.0 artefact for semconv 1.22.0.
+//
+// It records a gap as much as a guarantee. Most real metric groups declare their
+// attributes with extends, naming an attribute_group to inherit from, and
+// semconvGroup has no such field: those groups parse with no attributes at all, so
+// nothing canonicalises their attribute names across a rename and no
+// apply_to_metrics scoping applies to them either. Only groups that list attributes
+// inline are seen. If extends is resolved later, the second assertion here is the
+// one that should change.
+func TestUpstreamSemconvAttributes(t *testing.T) {
+	b, err := os.ReadFile("./testdata/upstream/semconv-1.22.0.yaml")
+	require.NoError(t, err)
+	sc, err := loadSemconv(b, "1.22.0")
+	require.NoError(t, err)
+
+	// Declared inline, so they are parsed.
+	require.Contains(t, sc.attributesOf("http.server.active_requests"), "http.request.method",
+		"inline attributes of a real metric group must be parsed")
+
+	// Declared via "extends: metric_attributes.http.server", so they are not.
+	require.Empty(t, sc.attributesOf("http.server.request.duration"),
+		"extends is not resolved, so this group has no attributes; if that changes, so must this")
+
+	// Either way the group is indexed as a metric, which is what rename
+	// corroboration needs from it.
+	require.Contains(t, sc.metrics, "http.server.request.duration")
+	require.Equal(t, "s", sc.metrics["http.server.request.duration"].unit)
+	require.Equal(t, "histogram", sc.metrics["http.server.request.duration"].instrument)
+}

--- a/storage/semconv/otel_schema_test.go
+++ b/storage/semconv/otel_schema_test.go
@@ -55,13 +55,18 @@ func TestLoadOTelSchema(t *testing.T) {
 	t.Run("collects renames from the all section", func(t *testing.T) {
 		schema := loadOTelSchemaFile(t, "./testdata/otel_with_all_section.yaml")
 		require.Len(t, schema.versionRenames, 1)
-		attrs := schema.versionRenames[0].attributes
-		// Global ("all" section) renames are collected bidirectionally...
-		require.Equal(t, "global.new", attrs["global.old"])
-		require.Equal(t, "global.old", attrs["global.new"])
-		// ...alongside the metric-section renames.
-		require.Equal(t, "metric.new", attrs["metric.old"])
-		require.Equal(t, "metric.old", attrs["metric.new"])
+		renames := schema.versionRenames[0]
+		// Global ("all" section) renames apply to every metric and are collected
+		// bidirectionally.
+		require.Equal(t, "global.new", renames.attributes["global.old"])
+		require.Equal(t, "global.old", renames.attributes["global.new"])
+		// The metric-section rename names apply_to_metrics, so it is scoped to
+		// that metric rather than added to the global map.
+		require.NotContains(t, renames.attributes, "metric.old")
+		require.Equal(t, map[string]string{
+			"metric.old": "metric.new",
+			"metric.new": "metric.old",
+		}, renames.attributesPerMetric["my.metric"])
 	})
 
 	t.Run("collects per-version metric renames", func(t *testing.T) {
@@ -75,12 +80,41 @@ func TestLoadOTelSchema(t *testing.T) {
 		require.Equal(t, "another.old.metric", renames.metrics["another.new.metric"])
 	})
 
-	t.Run("collects per-version attribute renames", func(t *testing.T) {
+	t.Run("scopes per-version attribute renames to apply_to_metrics", func(t *testing.T) {
 		schema := loadOTelSchemaFile(t, "./testdata/otel.yaml")
 		require.Len(t, schema.versionRenames, 1)
 		renames := schema.versionRenames[0]
-		require.Equal(t, "http.request.method", renames.attributes["http.method"])
-		require.Equal(t, "http.method", renames.attributes["http.request.method"])
+
+		// This fixture declares two disjoint scopes: HTTP attribute renames for
+		// the two HTTP metrics, and process.cpu.state for process.cpu.time.
+		// Neither may leak into the other, nor into the global map.
+		require.Empty(t, renames.attributes)
+		for _, metric := range []string{"http.server.duration", "http.server.request.count"} {
+			scoped := renames.attributesPerMetric[metric]
+			require.Equal(t, "http.request.method", scoped["http.method"])
+			require.Equal(t, "http.method", scoped["http.request.method"])
+			require.NotContains(t, scoped, "process.cpu.state")
+		}
+		cpu := renames.attributesPerMetric["process.cpu.time"]
+		require.Equal(t, "cpu.mode", cpu["process.cpu.state"])
+		require.NotContains(t, cpu, "http.method")
+	})
+
+	t.Run("scoping narrows a version's renames per metric", func(t *testing.T) {
+		schema := loadOTelSchemaFile(t, "./testdata/otel.yaml")
+
+		// Resolving process.cpu.time must not pick up the HTTP metrics' renames.
+		scoped := scopedVersionRenames(schema.versionRenames,
+			metricNameAliases(schema.versionRenames, "process.cpu.time"))
+		require.Equal(t, "cpu.mode", scoped[0].attributes["process.cpu.state"])
+		require.NotContains(t, scoped[0].attributes, "http.method",
+			"a rename scoped to the HTTP metrics must not apply to process.cpu.time")
+
+		// ...and vice versa.
+		scoped = scopedVersionRenames(schema.versionRenames,
+			metricNameAliases(schema.versionRenames, "http.server.duration"))
+		require.Equal(t, "http.request.method", scoped[0].attributes["http.method"])
+		require.NotContains(t, scoped[0].attributes, "process.cpu.state")
 	})
 
 	t.Run("collects renames from multiple versions", func(t *testing.T) {

--- a/storage/semconv/registry/registry.yaml
+++ b/storage/semconv/registry/registry.yaml
@@ -8,8 +8,7 @@ versions:
     metrics:
       changes:
         - rename_metrics:
-            name_map:
-              test.counter: test
+            test.counter: test
         - rename_attributes:
             attribute_map:
               user: tenant
@@ -20,5 +19,4 @@ versions:
     metrics:
       changes:
         - rename_metrics:
-            name_map:
-              test: test.v2
+            test: test.v2

--- a/storage/semconv/storage.go
+++ b/storage/semconv/storage.go
@@ -229,16 +229,23 @@ func (q *awareQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	}
 
 	seriesSets := make([]storage.SeriesSet, len(variants))
-	g, gctx := errgroup.WithContext(ctx)
+	// Deliberately not errgroup.WithContext: a Select is lazy, so its context must
+	// outlive g.Wait() here, and WithContext cancels its derived context as soon as
+	// Wait returns. The variants are read only after that, which with a streaming
+	// underlying querier would abort the read mid-stream. Nothing here returns an
+	// error, so cancellation propagation buys nothing anyway.
+	var g errgroup.Group
 	g.SetLimit(fanOutLimit)
 	for i, ms := range variants {
 		g.Go(func() error {
-			// We must sort for NewMergeSeriesSet to work.
-			seriesSets[i] = &awareSeriesSet{
-				SeriesSet: q.Querier.Select(gctx, true, hints, ms...),
+			// Sorted, because NewMergeSeriesSet requires it. The underlying
+			// querier sorts by the stored names, and transformSeries then rewrites
+			// them, so the result has to be sorted again afterwards.
+			seriesSets[i] = newSortedSeriesSet(&awareSeriesSet{
+				SeriesSet: q.Querier.Select(ctx, true, hints, ms...),
 				engine:    q.engine,
 				qCtx:      qCtx,
-			}
+			})
 			return nil
 		})
 	}
@@ -286,15 +293,17 @@ func (q *awareChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *
 	}
 
 	chunkSeriesSets := make([]storage.ChunkSeriesSet, len(variants))
-	g, gctx := errgroup.WithContext(ctx)
+	// ctx rather than an errgroup-derived context, and sorted after the rewrite;
+	// see the Select above for both.
+	var g errgroup.Group
 	g.SetLimit(fanOutLimit)
 	for i, ms := range variants {
 		g.Go(func() error {
-			chunkSeriesSets[i] = &awareChunkSeriesSet{
-				ChunkSeriesSet: q.ChunkQuerier.Select(gctx, true, hints, ms...),
+			chunkSeriesSets[i] = newSortedChunkSeriesSet(&awareChunkSeriesSet{
+				ChunkSeriesSet: q.ChunkQuerier.Select(ctx, true, hints, ms...),
 				engine:         q.engine,
 				qCtx:           qCtx,
-			}
+			})
 			return nil
 		})
 	}
@@ -500,6 +509,111 @@ func (s *annotatedChunkSeriesSet) Warnings() annotations.Annotations {
 		got = got.Add(schemaWarning(w))
 	}
 	return got
+}
+
+// sortAndChain returns in sorted by labels, with each run of series carrying
+// identical labels collapsed into one via merge.
+//
+// Both are needed because rewriting labels can reorder a set and can make two
+// series collide. A variant queries one naming era and its series come back sorted
+// by that era's names; rewriting an attribute to its anchor-version name moves it
+// in the ordering, and two series distinguished only by the era of an attribute
+// name rewrite to the very same labels. storage.NewMergeSeriesSet assumes each
+// input reports strictly increasing labels, so it would emit the reordered series
+// out of order and the collided ones twice.
+func sortAndChain[T interface{ Labels() labels.Labels }](in []T, merge func(...T) T) []T {
+	slices.SortStableFunc(in, func(a, b T) int {
+		return labels.Compare(a.Labels(), b.Labels())
+	})
+	// A fresh slice, deliberately not in[:0]: the merge functions retain the slice
+	// they are handed and read it only when the merged series is iterated, so
+	// compacting in place would write a merged series back into the very range its
+	// own chain still points at, and iterating it would recurse forever.
+	out := make([]T, 0, len(in))
+	for i := 0; i < len(in); {
+		j := i + 1
+		for j < len(in) && labels.Equal(in[j].Labels(), in[i].Labels()) {
+			j++
+		}
+		if j-i == 1 {
+			out = append(out, in[i])
+		} else {
+			out = append(out, merge(in[i:j]...))
+		}
+		i = j
+	}
+	return out
+}
+
+// sortedSeriesSet re-sorts a series set whose labels have been rewritten, so it
+// can be fed to storage.NewMergeSeriesSet.
+//
+// It buffers the whole set on first use, which the SeriesSet contract permits:
+// "Returned series should be iterable even after Next is called", so only the
+// series handles are held, not their samples. That is the price of rewriting labels
+// before merging rather than after — the sort order is not known until every label
+// has been rewritten.
+type sortedSeriesSet struct {
+	storage.SeriesSet
+
+	series []storage.Series
+	idx    int
+	loaded bool
+}
+
+func newSortedSeriesSet(s storage.SeriesSet) storage.SeriesSet {
+	return &sortedSeriesSet{SeriesSet: s, idx: -1}
+}
+
+func (s *sortedSeriesSet) Next() bool {
+	if !s.loaded {
+		s.loaded = true
+		for s.SeriesSet.Next() {
+			s.series = append(s.series, s.SeriesSet.At())
+		}
+		s.series = sortAndChain(s.series, storage.ChainedSeriesMerge)
+	}
+	if s.Err() != nil {
+		return false
+	}
+	s.idx++
+	return s.idx < len(s.series)
+}
+
+func (s *sortedSeriesSet) At() storage.Series {
+	return s.series[s.idx]
+}
+
+// sortedChunkSeriesSet is sortedSeriesSet for chunk series; see there.
+type sortedChunkSeriesSet struct {
+	storage.ChunkSeriesSet
+
+	series []storage.ChunkSeries
+	idx    int
+	loaded bool
+}
+
+func newSortedChunkSeriesSet(s storage.ChunkSeriesSet) storage.ChunkSeriesSet {
+	return &sortedChunkSeriesSet{ChunkSeriesSet: s, idx: -1}
+}
+
+func (s *sortedChunkSeriesSet) Next() bool {
+	if !s.loaded {
+		s.loaded = true
+		for s.ChunkSeriesSet.Next() {
+			s.series = append(s.series, s.ChunkSeriesSet.At())
+		}
+		s.series = sortAndChain(s.series, storage.NewCompactingChunkSeriesMerger(storage.ChainedSeriesMerge))
+	}
+	if s.Err() != nil {
+		return false
+	}
+	s.idx++
+	return s.idx < len(s.series)
+}
+
+func (s *sortedChunkSeriesSet) At() storage.ChunkSeries {
+	return s.series[s.idx]
 }
 
 type awareSeriesSet struct {

--- a/storage/semconv/storage.go
+++ b/storage/semconv/storage.go
@@ -236,16 +236,33 @@ func (q *awareQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	// error, so cancellation propagation buys nothing anyway.
 	var g errgroup.Group
 	g.SetLimit(fanOutLimit)
+	resort := needsResort(qCtx)
 	for i, ms := range variants {
 		g.Go(func() error {
-			// Sorted, because NewMergeSeriesSet requires it. The underlying
-			// querier sorts by the stored names, and transformSeries then rewrites
-			// them, so the result has to be sorted again afterwards.
-			seriesSets[i] = newSortedSeriesSet(&awareSeriesSet{
+			set := storage.SeriesSet(&awareSeriesSet{
 				SeriesSet: q.Querier.Select(ctx, true, hints, ms...),
 				engine:    q.engine,
 				qCtx:      qCtx,
 			})
+			if resort {
+				// Left lazy on purpose, which means the drains happen one after
+				// another: NewMergeSeriesSet pre-advances every input when it is
+				// constructed, and advancing a buffering set drains it, so all of
+				// them drain on the caller's goroutine.
+				//
+				// Draining here instead, inside the group, would parallelise that
+				// but is not allowed. Only storage.Storage is goroutine-safe; a
+				// Querier is not, and tsdb's demonstrably is not — iterating a
+				// series set calls headIndexReader.Series, which writes to a scratch
+				// buffer shared by every set derived from the same querier. Two
+				// variants drained at once corrupt it. Selecting concurrently is
+				// fine, since the sets are only built there and not read.
+				//
+				// Parallelising the drain means one Querier per variant, which is a
+				// change to what a fan-out holds open, not just to where load runs.
+				set = newSortedSeriesSet(set)
+			}
+			seriesSets[i] = set
 			return nil
 		})
 	}
@@ -293,17 +310,23 @@ func (q *awareChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *
 	}
 
 	chunkSeriesSets := make([]storage.ChunkSeriesSet, len(variants))
-	// ctx rather than an errgroup-derived context, and sorted after the rewrite;
-	// see the Select above for both.
+	// ctx rather than an errgroup-derived context, and re-sorted only where a
+	// rewrite can reorder a set, draining inside the group; see the Select above.
 	var g errgroup.Group
 	g.SetLimit(fanOutLimit)
+	resort := needsResort(qCtx)
 	for i, ms := range variants {
 		g.Go(func() error {
-			chunkSeriesSets[i] = newSortedChunkSeriesSet(&awareChunkSeriesSet{
+			set := storage.ChunkSeriesSet(&awareChunkSeriesSet{
 				ChunkSeriesSet: q.ChunkQuerier.Select(ctx, true, hints, ms...),
 				engine:         q.engine,
 				qCtx:           qCtx,
 			})
+			if resort {
+				// Lazy, so the drains do not overlap; see the Select above.
+				set = newSortedChunkSeriesSet(set)
+			}
+			chunkSeriesSets[i] = set
 			return nil
 		})
 	}
@@ -521,6 +544,25 @@ func (s *annotatedChunkSeriesSet) Warnings() annotations.Annotations {
 	return got
 }
 
+// needsResort reports whether rewriting a variant's labels can change the order
+// the underlying querier returned them in, which is what decides whether a variant
+// has to be buffered and sorted before the merge sees it.
+//
+// Only an attribute rename can. Every series in a variant matches the same equality
+// matcher on __name__, so rewriting the metric name replaces the same value in all
+// of them and leaves their relative order alone; renaming an attribute moves that
+// label within a series and so moves the series within the set. Two series can also
+// collide on the rewritten labels, but only by differing in a renamed attribute's
+// name, so the same condition covers it.
+//
+// This takes it that no stored series carries the reserved __semconv_url__ /
+// __schema_url__ labels, which transformSeries strips and whose removal could
+// likewise reorder a set. They are query-time matchers that nothing writes, and
+// __-prefixed labels are dropped from scraped samples.
+func needsResort(qCtx queryContext) bool {
+	return qCtx.labelMapping != nil && len(qCtx.labelMapping.translatedLabels) > 0
+}
+
 // sortAndChain returns in sorted by labels, with each run of series carrying
 // identical labels collapsed into one via merge.
 //
@@ -571,18 +613,25 @@ type sortedSeriesSet struct {
 	loaded bool
 }
 
-func newSortedSeriesSet(s storage.SeriesSet) storage.SeriesSet {
+func newSortedSeriesSet(s storage.SeriesSet) *sortedSeriesSet {
 	return &sortedSeriesSet{SeriesSet: s, idx: -1}
 }
 
-func (s *sortedSeriesSet) Next() bool {
-	if !s.loaded {
-		s.loaded = true
-		for s.SeriesSet.Next() {
-			s.series = append(s.series, s.SeriesSet.At())
-		}
-		s.series = sortAndChain(s.series, storage.ChainedSeriesMerge)
+// load drains and sorts the underlying set, on the first Next. It must stay on the
+// reading goroutine: the underlying querier is not safe to iterate concurrently.
+func (s *sortedSeriesSet) load() {
+	if s.loaded {
+		return
 	}
+	s.loaded = true
+	for s.SeriesSet.Next() {
+		s.series = append(s.series, s.SeriesSet.At())
+	}
+	s.series = sortAndChain(s.series, storage.ChainedSeriesMerge)
+}
+
+func (s *sortedSeriesSet) Next() bool {
+	s.load()
 	if s.Err() != nil {
 		return false
 	}
@@ -603,18 +652,25 @@ type sortedChunkSeriesSet struct {
 	loaded bool
 }
 
-func newSortedChunkSeriesSet(s storage.ChunkSeriesSet) storage.ChunkSeriesSet {
+func newSortedChunkSeriesSet(s storage.ChunkSeriesSet) *sortedChunkSeriesSet {
 	return &sortedChunkSeriesSet{ChunkSeriesSet: s, idx: -1}
 }
 
-func (s *sortedChunkSeriesSet) Next() bool {
-	if !s.loaded {
-		s.loaded = true
-		for s.ChunkSeriesSet.Next() {
-			s.series = append(s.series, s.ChunkSeriesSet.At())
-		}
-		s.series = sortAndChain(s.series, storage.NewCompactingChunkSeriesMerger(storage.ChainedSeriesMerge))
+// load drains and sorts the underlying set on the first Next; see
+// sortedSeriesSet.load.
+func (s *sortedChunkSeriesSet) load() {
+	if s.loaded {
+		return
 	}
+	s.loaded = true
+	for s.ChunkSeriesSet.Next() {
+		s.series = append(s.series, s.ChunkSeriesSet.At())
+	}
+	s.series = sortAndChain(s.series, storage.NewCompactingChunkSeriesMerger(storage.ChainedSeriesMerge))
+}
+
+func (s *sortedChunkSeriesSet) Next() bool {
+	s.load()
 	if s.Err() != nil {
 		return false
 	}

--- a/storage/semconv/storage.go
+++ b/storage/semconv/storage.go
@@ -243,7 +243,11 @@ func (q *awareQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 		})
 	}
 	_ = g.Wait()
-	return storage.NewMergeSeriesSet(seriesSets, 0, storage.ChainedSeriesMerge)
+	merged := storage.NewMergeSeriesSet(seriesSets, 0, storage.ChainedSeriesMerge)
+	if len(qCtx.warnings) > 0 {
+		return annotateSeriesSet(merged, qCtx.warnings...)
+	}
+	return merged
 }
 
 func (q *awareQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
@@ -295,7 +299,11 @@ func (q *awareChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *
 		})
 	}
 	_ = g.Wait()
-	return storage.NewMergeChunkSeriesSet(chunkSeriesSets, 0, storage.NewCompactingChunkSeriesMerger(storage.ChainedSeriesMerge))
+	merged := storage.NewMergeChunkSeriesSet(chunkSeriesSets, 0, storage.NewCompactingChunkSeriesMerger(storage.ChainedSeriesMerge))
+	if len(qCtx.warnings) > 0 {
+		return annotateChunkSeriesSet(merged, qCtx.warnings...)
+	}
+	return merged
 }
 
 func (q *awareChunkQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
@@ -369,7 +377,7 @@ func queryLabelNames(ctx context.Context, q labelQuerier, e *schemaEngine, hints
 		}
 	}
 	slices.Sort(combined)
-	return combined, combinedAnns, errors.Join(errs...)
+	return combined, addWarnings(combinedAnns, qCtx), errors.Join(errs...)
 }
 
 func queryLabelValues(ctx context.Context, q labelQuerier, e *schemaEngine, name string, hints *storage.LabelHints, matchers []*labels.Matcher) ([]string, annotations.Annotations, error) {
@@ -447,37 +455,51 @@ func queryLabelValues(ctx context.Context, q labelQuerier, e *schemaEngine, name
 		}
 	}
 	slices.Sort(combined)
-	return combined, combinedAnns, errors.Join(errs...)
+	return combined, addWarnings(combinedAnns, qCtx), errors.Join(errs...)
 }
 
 type annotatedSeriesSet struct {
 	storage.SeriesSet
 
-	warning string
+	warnings []string
 }
 
-func annotateSeriesSet(s storage.SeriesSet, warning string) storage.SeriesSet {
-	return &annotatedSeriesSet{warning: warning, SeriesSet: s}
+func annotateSeriesSet(s storage.SeriesSet, warnings ...string) storage.SeriesSet {
+	return &annotatedSeriesSet{warnings: warnings, SeriesSet: s}
 }
 
 func (s *annotatedSeriesSet) Warnings() annotations.Annotations {
 	got := s.SeriesSet.Warnings()
-	return got.Add(schemaWarning(s.warning))
+	for _, w := range s.warnings {
+		got = got.Add(schemaWarning(w))
+	}
+	return got
+}
+
+// addWarnings merges the query-resolution warnings collected in qCtx into anns.
+func addWarnings(anns annotations.Annotations, qCtx queryContext) annotations.Annotations {
+	for _, w := range qCtx.warnings {
+		anns = anns.Add(schemaWarning(w))
+	}
+	return anns
 }
 
 type annotatedChunkSeriesSet struct {
 	storage.ChunkSeriesSet
 
-	warning string
+	warnings []string
 }
 
-func annotateChunkSeriesSet(s storage.ChunkSeriesSet, warning string) storage.ChunkSeriesSet {
-	return &annotatedChunkSeriesSet{warning: warning, ChunkSeriesSet: s}
+func annotateChunkSeriesSet(s storage.ChunkSeriesSet, warnings ...string) storage.ChunkSeriesSet {
+	return &annotatedChunkSeriesSet{warnings: warnings, ChunkSeriesSet: s}
 }
 
 func (s *annotatedChunkSeriesSet) Warnings() annotations.Annotations {
 	got := s.ChunkSeriesSet.Warnings()
-	return got.Add(schemaWarning(s.warning))
+	for _, w := range s.warnings {
+		got = got.Add(schemaWarning(w))
+	}
+	return got
 }
 
 type awareSeriesSet struct {

--- a/storage/semconv/storage.go
+++ b/storage/semconv/storage.go
@@ -377,6 +377,11 @@ func queryLabelNames(ctx context.Context, q labelQuerier, e *schemaEngine, hints
 		}
 		combinedAnns.Merge(p.anns)
 		for _, n := range p.names {
+			if isReservedLabel(n) {
+				// Select strips these from the series it returns, so reporting
+				// them as label names would advertise labels no series carries.
+				continue
+			}
 			canonical := reverseLabelName(qCtx, n)
 			if _, ok := seen[canonical]; ok {
 				continue
@@ -414,7 +419,12 @@ func queryLabelValues(ctx context.Context, q labelQuerier, e *schemaEngine, name
 	// values; mismatched (variant, alias) pairs simply return nothing. For
 	// __name__ there are no attribute aliases (aliasesOf returns just the name),
 	// and its values are collapsed to the canonical metric below.
-	aliases := qCtx.labelMapping.aliasesOf(name)
+	//
+	// name is canonicalised first, so asking for a historical name of a renamed
+	// attribute fans out over the same alias set as asking for its anchor-version
+	// name; otherwise aliasesOf, which only expands a canonical name, would return
+	// the historical name alone and miss every other era.
+	aliases := qCtx.labelMapping.aliasesOf(reverseLabelName(qCtx, name))
 
 	type partial struct {
 		values []string

--- a/storage/semconv/storage_fanout_test.go
+++ b/storage/semconv/storage_fanout_test.go
@@ -1,0 +1,123 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+// TestFanOutResultIsSorted checks that a variant whose labels were rewritten is
+// re-sorted before it reaches the merge.
+//
+// Each variant is queried sorted by the names stored for its own era, and rewriting
+// an attribute to its anchor-version name reorders it: here "ttt" sorts after "user"
+// but before "tenant". storage.NewMergeSeriesSet assumes every input reports
+// strictly increasing labels, so feeding it the rewritten set unsorted let it emit
+// series out of order and, where two eras rewrote to the same labels, twice — a
+// duplicate labelset PromQL rejects.
+//
+// The samples are asserted, not just the labels. A merged series computes its labels
+// eagerly and its samples only when iterated, so a chain built over a slice the
+// merge function still holds looks perfectly well-formed until something reads it.
+func TestFanOutResultIsSorted(t *testing.T) {
+	// Stored under the 1.0.0 name, so all of these come back in one variant.
+	// "user" is rewritten to "tenant" at the 1.1.0 anchor, which moves it before
+	// "ttt"; the two "1" series collide on the rewritten labels.
+	appendAll := func(t *testing.T, s storage.Storage) {
+		t.Helper()
+		appendSeries(t, s, "test.counter", 1, 1.0, "ttt", "2")
+		appendSeries(t, s, "test.counter", 1, 2.0, "user", "1")
+		appendSeries(t, s, "test.counter", 2, 3.0, "tenant", "1")
+	}
+	// The two colliding series chain into one, so it carries both their samples.
+	want := []seriesWithSamples{
+		{
+			lset:    labels.FromStrings(model.MetricNameLabel, "test", "tenant", "1"),
+			samples: []sample{{t: 1, v: 2.0}, {t: 2, v: 3.0}},
+		},
+		{
+			lset:    labels.FromStrings(model.MetricNameLabel, "test", "ttt", "2"),
+			samples: []sample{{t: 1, v: 1.0}},
+		},
+	}
+
+	t.Run("querier", func(t *testing.T) {
+		wrapped, _ := newAwareStorage(t)
+		appendAll(t, wrapped)
+
+		set := selectAt(t, wrapped, "1.1.0", "test")
+
+		got := collectWithSamples(t, set)
+		require.Equal(t, want, got, "expected strictly increasing labels with no duplicates")
+	})
+
+	t.Run("chunk querier", func(t *testing.T) {
+		wrapped, _ := newAwareStorage(t)
+		appendAll(t, wrapped)
+
+		cq, err := wrapped.ChunkQuerier(0, 10)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = cq.Close() })
+
+		set := cq.Select(context.Background(), false, nil,
+			labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test"),
+			labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.1.0"),
+			labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+		)
+
+		got := collectWithSamples(t, storage.NewSeriesSetFromChunkSeriesSet(set))
+		require.Equal(t, want, got, "expected strictly increasing labels with no duplicates")
+	})
+}
+
+type sample struct {
+	t int64
+	v float64
+}
+
+type seriesWithSamples struct {
+	lset    labels.Labels
+	samples []sample
+}
+
+// collectWithSamples drains a series set in order, reading each series' samples.
+// Unlike collectSeries it keeps the order and every sample, which is what a set
+// fed to a merge has to be checked on: the merge computes a series' labels
+// eagerly and its samples lazily, so a malformed chain shows only when read.
+func collectWithSamples(t *testing.T, set storage.SeriesSet) []seriesWithSamples {
+	t.Helper()
+	var out []seriesWithSamples
+	for set.Next() {
+		s := set.At()
+		got := seriesWithSamples{lset: s.Labels()}
+		it := s.Iterator(nil)
+		for it.Next() == chunkenc.ValFloat {
+			ts, v := it.At()
+			got.samples = append(got.samples, sample{t: ts, v: v})
+			require.LessOrEqual(t, len(got.samples), 16, "runaway iteration on %s", got.lset)
+		}
+		require.NoError(t, it.Err())
+		out = append(out, got)
+	}
+	require.NoError(t, set.Err())
+	return out
+}

--- a/storage/semconv/storage_fanout_test.go
+++ b/storage/semconv/storage_fanout_test.go
@@ -171,3 +171,91 @@ func collectWithSamples(t *testing.T, set storage.SeriesSet) []seriesWithSamples
 	require.NoError(t, set.Err())
 	return out
 }
+
+// ctxCheckingStorage returns series sets that fail if the context they were
+// selected with has been cancelled by the time they are read, which is what an
+// underlying querier streaming from a remote does implicitly.
+type ctxCheckingStorage struct {
+	storage.Storage
+}
+
+func (s ctxCheckingStorage) Querier(mint, maxt int64) (storage.Querier, error) {
+	q, err := s.Storage.Querier(mint, maxt)
+	if err != nil {
+		return nil, err
+	}
+	return ctxCheckingQuerier{Querier: q}, nil
+}
+
+type ctxCheckingQuerier struct {
+	storage.Querier
+}
+
+func (q ctxCheckingQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	return &ctxCheckingSeriesSet{
+		SeriesSet: q.Querier.Select(ctx, sortSeries, hints, matchers...),
+		ctx:       ctx,
+	}
+}
+
+type ctxCheckingSeriesSet struct {
+	storage.SeriesSet
+
+	ctx context.Context
+	err error
+}
+
+func (s *ctxCheckingSeriesSet) Next() bool {
+	if err := s.ctx.Err(); err != nil {
+		s.err = err
+		return false
+	}
+	return s.SeriesSet.Next()
+}
+
+func (s *ctxCheckingSeriesSet) Err() error {
+	if s.err != nil {
+		return s.err
+	}
+	return s.SeriesSet.Err()
+}
+
+// TestFanOutKeepsSelectContextAlive checks that the context handed to the underlying
+// Select outlives the fan-out's errgroup.
+//
+// A Select is lazy, so its context has to stay valid until the result is read.
+// errgroup.WithContext cancels its context the moment Wait returns, which is before
+// anything reads a variant, and against a streaming querier that aborts the read
+// mid-stream. The in-memory test storage never notices, since tsdb only checks the
+// context every 100 iterations, so this asserts it through a querier that checks on
+// every one.
+func TestFanOutKeepsSelectContextAlive(t *testing.T) {
+	wrapped, err := semconv.AwareStorageWithRegistry(
+		ctxCheckingStorage{Storage: teststorage.New(t)},
+		map[string][]byte{
+			"registry.yaml": []byte(benchMetricRenameSchema),
+			"1.0.0":         []byte(fmt.Sprintf(benchSemconv, "bench.old", "attr.old")),
+			"1.1.0":         []byte(fmt.Sprintf(benchSemconv, "bench.new", "attr.new")),
+		})
+	require.NoError(t, err)
+
+	appendSeries(t, wrapped, "bench.old", 1, 1.0, "attr.old", "a")
+	appendSeries(t, wrapped, "bench.new", 1, 2.0, "attr.new", "b")
+
+	q, err := wrapped.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	set := q.Select(context.Background(), false, nil,
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "bench.new"),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.1.0"),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	)
+
+	var got int
+	for set.Next() {
+		got++
+	}
+	require.NoError(t, set.Err(), "the variants were read with a cancelled context")
+	require.Equal(t, 2, got, "both eras must be returned")
+}

--- a/storage/semconv/storage_fanout_test.go
+++ b/storage/semconv/storage_fanout_test.go
@@ -15,6 +15,7 @@ package semconv_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -22,7 +23,9 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/semconv"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/teststorage"
 )
 
 // TestFanOutResultIsSorted checks that a variant whose labels were rewritten is
@@ -87,6 +90,53 @@ func TestFanOutResultIsSorted(t *testing.T) {
 		got := collectWithSamples(t, storage.NewSeriesSetFromChunkSeriesSet(set))
 		require.Equal(t, want, got, "expected strictly increasing labels with no duplicates")
 	})
+}
+
+// TestFanOutWithoutAttributeRenameIsSorted guards the assumption that lets a
+// variant stream instead of being buffered and sorted: when the schema renames only
+// the metric, every series in a variant matches the same equality matcher on
+// __name__, so they all get the same replacement and the order the underlying
+// querier returned them in survives. Output must be sorted with no variant sorted
+// after the fact.
+func TestFanOutWithoutAttributeRenameIsSorted(t *testing.T) {
+	wrapped, err := semconv.AwareStorageWithRegistry(teststorage.New(t), map[string][]byte{
+		"registry.yaml": []byte(benchMetricRenameSchema),
+		"1.0.0":         []byte(fmt.Sprintf(benchSemconv, "bench.old", "attr.old")),
+		"1.1.0":         []byte(fmt.Sprintf(benchSemconv, "bench.new", "attr.new")),
+	})
+	require.NoError(t, err)
+
+	// attr.old and attr.new are distinct labels that the schema does not rename, so
+	// nothing rewrites them and the eras interleave in the merged order.
+	appendSeries(t, wrapped, "bench.old", 1, 1.0, "attr.old", "zzz")
+	appendSeries(t, wrapped, "bench.old", 1, 2.0, "attr.old", "aaa")
+	appendSeries(t, wrapped, "bench.new", 1, 3.0, "attr.new", "mmm")
+
+	q, err := wrapped.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	set := q.Select(context.Background(), false, nil,
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "bench.new"),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.1.0"),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	)
+
+	got := collectWithSamples(t, set)
+	require.Equal(t, []seriesWithSamples{
+		{
+			lset:    labels.FromStrings(model.MetricNameLabel, "bench.new", "attr.new", "mmm"),
+			samples: []sample{{t: 1, v: 3.0}},
+		},
+		{
+			lset:    labels.FromStrings(model.MetricNameLabel, "bench.new", "attr.old", "aaa"),
+			samples: []sample{{t: 1, v: 2.0}},
+		},
+		{
+			lset:    labels.FromStrings(model.MetricNameLabel, "bench.new", "attr.old", "zzz"),
+			samples: []sample{{t: 1, v: 1.0}},
+		},
+	}, got)
 }
 
 type sample struct {

--- a/storage/semconv/storage_labels_test.go
+++ b/storage/semconv/storage_labels_test.go
@@ -1,0 +1,69 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// TestLabelValuesCanonicalisesTheQueriedName asks for the values of a renamed
+// attribute under its pre-rename name. The name is canonicalised first, so the
+// fan-out covers the same aliases as asking under the anchor-version name;
+// otherwise only the era that happens to store the attribute under the name as
+// given contributes any values.
+func TestLabelValuesCanonicalisesTheQueriedName(t *testing.T) {
+	wrapped, _ := newAwareStorage(t)
+	appendSeries(t, wrapped, "test.counter", 1, 1.0, "user", "a")
+	appendSeries(t, wrapped, "test", 1, 2.0, "tenant", "b")
+
+	q, err := wrapped.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test"),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.1.0"),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	}
+	// "user" is the 1.0.0 name of the attribute the 1.1.0 anchor calls "tenant".
+	values, _, err := q.LabelValues(context.Background(), "user", nil, matchers...)
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, values)
+}
+
+// TestLabelNamesHidesReservedLabels checks that the reserved matcher labels are
+// not reported as label names. Select strips them from the series it returns, so
+// reporting them would advertise labels no series carries.
+func TestLabelNamesHidesReservedLabels(t *testing.T) {
+	wrapped, _ := newAwareStorage(t)
+	appendSeries(t, wrapped, "test", 1, 1.0, "tenant", "a", "__schema_url__", "registry/registry.yaml")
+
+	q, err := wrapped.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	names, _, err := q.LabelNames(context.Background(), nil,
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test"),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.1.0"),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{model.MetricNameLabel, "tenant"}, names)
+}

--- a/storage/semconv/storage_rename_validation_test.go
+++ b/storage/semconv/storage_rename_validation_test.go
@@ -1,0 +1,255 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage/semconv"
+	"github.com/prometheus/prometheus/util/teststorage"
+)
+
+// renameSchema is a two-version schema renaming old→new at 1.1.0, the shape
+// every case below varies the semconv files around.
+const renameSchema = `file_format: 1.1.0
+schema_url: https://example.com/schemas/1.1.0
+versions:
+  1.0.0:
+  1.1.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            name_map:
+              %s: %s
+`
+
+// metricSemconv renders a semconv file declaring a single metric group. The
+// group id follows the "metric.<metric_name>" form that upstream semantic
+// conventions lint for, so it necessarily changes whenever the metric name does.
+func metricSemconv(metricName, unit, instrument string) []byte {
+	return []byte(fmt.Sprintf(`groups:
+  - id: metric.%s
+    type: metric
+    metric_name: %s
+    unit: %q
+    instrument: %s
+    attributes:
+      - ref: http.response.status_code
+`, metricName, metricName, unit, instrument))
+}
+
+// selectRenamed queries metricName anchored at semconv 1.1.0 over the given
+// registry and returns the series found plus any warnings raised.
+func selectRenamed(t *testing.T, files map[string][]byte, appendUnder, metricName string) (map[string]float64, []string) {
+	t.Helper()
+	underlying := teststorage.New(t)
+	wrapped, err := semconv.AwareStorageWithRegistry(underlying, files)
+	require.NoError(t, err)
+
+	appendSeries(t, wrapped, appendUnder, 1, 7.0, "http.response.status_code", "200")
+
+	q, err := wrapped.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	set := q.Select(context.Background(), false, nil,
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, metricName),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.1.0"),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	)
+	got := collectSeries(t, set)
+	return got, warningStrings(set.Warnings())
+}
+
+func TestRenameEdgeValidation(t *testing.T) {
+	// A legitimate rename: the metric is the same measurement under a new name,
+	// so unit and instrument agree and the historical series must still merge.
+	//
+	// This is also the case that rules out using the semconv group id as a
+	// cross-version identity: the ids here are metric.old.name and
+	// metric.new.name, so requiring them to be equal across the edge would
+	// reject this rename even though it is exactly the rename the schema exists
+	// to describe.
+	t.Run("merges a rename whose unit and instrument agree", func(t *testing.T) {
+		got, warnings := selectRenamed(t, map[string][]byte{
+			"registry.yaml": []byte(fmt.Sprintf(renameSchema, "old.name", "new.name")),
+			"1.0.0":         metricSemconv("old.name", "s", "histogram"),
+			"1.1.0":         metricSemconv("new.name", "s", "histogram"),
+		}, "old.name", "new.name")
+
+		require.Len(t, got, 1, "expected the pre-rename series under the queried name, got %v", got)
+		for k := range got {
+			require.Contains(t, k, `__name__="new.name"`)
+		}
+		require.Empty(t, warnings, "a corroborated rename must not warn")
+	})
+
+	// The case the schema format cannot express and name traversal cannot
+	// detect: two unrelated metrics that happen to share a surface name at
+	// different versions. Their units disagree, so merging them would average
+	// seconds with a queue depth.
+	t.Run("does not merge a rename whose unit disagrees", func(t *testing.T) {
+		got, warnings := selectRenamed(t, map[string][]byte{
+			"registry.yaml": []byte(fmt.Sprintf(renameSchema, "old.name", "new.name")),
+			"1.0.0":         metricSemconv("old.name", "{item}", "updowncounter"),
+			"1.1.0":         metricSemconv("new.name", "s", "histogram"),
+		}, "old.name", "new.name")
+
+		require.Empty(t, got, "series of a differently-united metric must not be merged in, got %v", got)
+		requireWarningsContain(t, warnings, "treating them as different metrics")
+		requireWarningsContain(t, warnings, `renames "old.name" to "new.name"`)
+	})
+
+	// Same unit, different instrument: a histogram and a counter are not the
+	// same metric even when they measure in the same unit.
+	t.Run("does not merge a rename whose instrument disagrees", func(t *testing.T) {
+		got, warnings := selectRenamed(t, map[string][]byte{
+			"registry.yaml": []byte(fmt.Sprintf(renameSchema, "old.name", "new.name")),
+			"1.0.0":         metricSemconv("old.name", "s", "counter"),
+			"1.1.0":         metricSemconv("new.name", "s", "histogram"),
+		}, "old.name", "new.name")
+
+		require.Empty(t, got, "got %v", got)
+		requireWarningsContain(t, warnings, "treating them as different metrics")
+	})
+
+	// A registry need not ship a semconv for every version its schema
+	// references, so an absent file means "cannot verify" and must leave the
+	// existing name-traversal behaviour untouched rather than drop series.
+	t.Run("traverses unverifiable renames unchanged when a semconv is absent", func(t *testing.T) {
+		got, warnings := selectRenamed(t, map[string][]byte{
+			"registry.yaml": []byte(fmt.Sprintf(renameSchema, "old.name", "new.name")),
+			"1.1.0":         metricSemconv("new.name", "s", "histogram"),
+		}, "old.name", "new.name")
+
+		require.Len(t, got, 1, "expected the pre-rename series to still merge, got %v", got)
+		require.Empty(t, warnings, "an unverifiable rename is not evidence of a problem")
+	})
+
+	// A name the semconv does not declare as a metric is a strong hint of a
+	// mis-authored edge, but a trimmed registry is a legitimate shape, so this
+	// is reported without dropping series.
+	t.Run("warns but still merges when a name is not declared as a metric", func(t *testing.T) {
+		got, warnings := selectRenamed(t, map[string][]byte{
+			"registry.yaml": []byte(fmt.Sprintf(renameSchema, "typo.name", "new.name")),
+			"1.0.0":         metricSemconv("old.name", "s", "histogram"),
+			"1.1.0":         metricSemconv("new.name", "s", "histogram"),
+		}, "typo.name", "new.name")
+
+		require.Len(t, got, 1, "expected the series to still merge, got %v", got)
+		requireWarningsContain(t, warnings, "could not be corroborated")
+	})
+}
+
+func TestAmbiguousMetricNameWarns(t *testing.T) {
+	// Two groups declaring the same metric_name: the collision that previously
+	// resolved to whichever group was parsed last, with no warning.
+	ambiguous := []byte(`groups:
+  - id: metric.shared.name
+    type: metric
+    metric_name: shared.name
+    unit: "s"
+    instrument: histogram
+    attributes:
+      - ref: http.response.status_code
+  - id: metric.shared.name.other
+    type: metric
+    metric_name: shared.name
+    unit: "{item}"
+    instrument: updowncounter
+    attributes:
+      - ref: queue.name
+`)
+
+	underlying := teststorage.New(t)
+	wrapped, err := semconv.AwareStorageWithRegistry(underlying, map[string][]byte{
+		"registry.yaml": []byte(fmt.Sprintf(renameSchema, "old.name", "other.name")),
+		"1.1.0":         ambiguous,
+	})
+	require.NoError(t, err)
+
+	appendSeries(t, wrapped, "shared.name", 1, 7.0)
+
+	q, err := wrapped.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "shared.name"),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.1.0"),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	}
+
+	t.Run("Select", func(t *testing.T) {
+		set := q.Select(context.Background(), false, nil, matchers...)
+		require.NotEmpty(t, collectSeries(t, set))
+		requireWarningsContain(t, warningStrings(set.Warnings()), "declared by more than one group")
+	})
+
+	t.Run("LabelNames", func(t *testing.T) {
+		_, anns, err := q.LabelNames(context.Background(), nil, matchers...)
+		require.NoError(t, err)
+		requireWarningsContain(t, warningStrings(anns), "declared by more than one group")
+	})
+
+	t.Run("LabelValues", func(t *testing.T) {
+		_, anns, err := q.LabelValues(context.Background(), "http.response.status_code", nil, matchers...)
+		require.NoError(t, err)
+		requireWarningsContain(t, warningStrings(anns), "declared by more than one group")
+	})
+}
+
+// TestChunkQuerierSurfacesWarnings checks the ChunkQuerier path annotates too,
+// since it fans out through the same resolver as Querier.
+func TestChunkQuerierSurfacesWarnings(t *testing.T) {
+	underlying := teststorage.New(t)
+	wrapped, err := semconv.AwareStorageWithRegistry(underlying, map[string][]byte{
+		"registry.yaml": []byte(fmt.Sprintf(renameSchema, "old.name", "new.name")),
+		"1.0.0":         metricSemconv("old.name", "{item}", "updowncounter"),
+		"1.1.0":         metricSemconv("new.name", "s", "histogram"),
+	})
+	require.NoError(t, err)
+	appendSeries(t, wrapped, "new.name", 1, 7.0)
+
+	cq, err := wrapped.ChunkQuerier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cq.Close() })
+
+	set := cq.Select(context.Background(), false, nil,
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "new.name"),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.1.0"),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	)
+	var n int
+	for set.Next() {
+		n++
+	}
+	require.NoError(t, set.Err())
+	require.Equal(t, 1, n, "the queried metric's own series must still be returned")
+
+	var found bool
+	for _, w := range warningStrings(set.Warnings()) {
+		if strings.Contains(w, "treating them as different metrics") {
+			found = true
+		}
+	}
+	require.True(t, found, "expected the chunk querier to surface the mis-linked rename warning")
+}

--- a/storage/semconv/storage_rename_validation_test.go
+++ b/storage/semconv/storage_rename_validation_test.go
@@ -395,3 +395,88 @@ func TestChunkQuerierSurfacesWarnings(t *testing.T) {
 	}
 	require.True(t, found, "expected the chunk querier to surface the mis-linked rename warning")
 }
+
+// recycledSchema retires old.name at 1.1.0 and hands the name to an unrelated
+// metric at 1.2.0, so the name has two eras and they need not mean the same thing.
+const recycledSchema = `file_format: 1.1.0
+schema_url: https://example.com/schemas/1.1.0
+versions:
+  1.0.0:
+  1.1.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            old.name: new.name
+  1.2.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            other.name: old.name
+`
+
+// TestRenameValidationWithoutAnchorDeclaration covers querying a name the anchor
+// semconv does not declare, which is ordinary input here: the fan-out deliberately
+// supports asking for a name the anchor version has already renamed away.
+//
+// Corroboration used to switch itself off silently for exactly that query, which is
+// the case it exists for. The identity of the queried metric is instead taken from a
+// version where the name is the current one, and only where no version settles it is
+// the check skipped — and then said so.
+func TestRenameValidationWithoutAnchorDeclaration(t *testing.T) {
+	t.Run("corroborates against the era that declares the queried name", func(t *testing.T) {
+		// Semconv 1.1.0 knows only new.name, so the queried old.name is resolved
+		// against 1.0.0, where it is current. The two disagree on unit and
+		// instrument, so the rename joins unrelated metrics and must not merge.
+		got, warnings := selectRenamed(t, map[string][]byte{
+			"registry.yaml": []byte(fmt.Sprintf(renameSchema, "old.name", "new.name")),
+			"1.0.0":         metricSemconv("old.name", "{item}", "updowncounter"),
+			"1.1.0":         metricSemconv("new.name", "s", "histogram"),
+		}, "new.name", "old.name")
+
+		require.Empty(t, got, "the contradicted rename must not pull in the other metric's series, got %v", got)
+		requireWarningsContain(t, warnings, "treating them as different metrics")
+	})
+
+	t.Run("merges when the era that declares the queried name agrees", func(t *testing.T) {
+		got, warnings := selectRenamed(t, map[string][]byte{
+			"registry.yaml": []byte(fmt.Sprintf(renameSchema, "old.name", "new.name")),
+			"1.0.0":         metricSemconv("old.name", "s", "histogram"),
+			"1.1.0":         metricSemconv("new.name", "s", "histogram"),
+		}, "new.name", "old.name")
+
+		require.Len(t, got, 1, "expected the renamed series under the queried name, got %v", got)
+		for k := range got {
+			require.Contains(t, k, `__name__="old.name"`)
+		}
+		require.Empty(t, warnings, "a corroborated rename must not warn")
+	})
+
+	t.Run("warns when no version declares the queried name", func(t *testing.T) {
+		// Nothing declares old.name anywhere, so there is no identity to check
+		// hops against. The series still merge, but the caller is told the
+		// corroboration did not run rather than left to assume it passed.
+		got, warnings := selectRenamed(t, map[string][]byte{
+			"registry.yaml": []byte(fmt.Sprintf(renameSchema, "old.name", "new.name")),
+			"1.0.0":         metricSemconv("unrelated.name", "s", "histogram"),
+			"1.1.0":         metricSemconv("new.name", "s", "histogram"),
+		}, "new.name", "old.name")
+
+		require.Len(t, got, 1, "an unverifiable rename is still followed, got %v", got)
+		requireWarningsContain(t, warnings, "without corroboration")
+	})
+
+	t.Run("warns when the queried name's eras disagree on what it is", func(t *testing.T) {
+		// old.name is current at 1.0.0 and again at 1.2.0, as two different
+		// metrics. Neither era can stand in for the other, so picking one would
+		// check hops against an identity the caller never asked for.
+		got, warnings := selectRenamed(t, map[string][]byte{
+			"registry.yaml": []byte(recycledSchema),
+			"1.0.0":         metricSemconv("old.name", "{item}", "updowncounter"),
+			"1.1.0":         metricSemconv("new.name", "s", "histogram"),
+			"1.2.0":         metricSemconv("old.name", "s", "histogram"),
+		}, "new.name", "old.name")
+
+		require.Len(t, got, 1, "an unverifiable rename is still followed, got %v", got)
+		requireWarningsContain(t, warnings, "without corroboration")
+	})
+}

--- a/storage/semconv/storage_rename_validation_test.go
+++ b/storage/semconv/storage_rename_validation_test.go
@@ -37,8 +37,7 @@ versions:
     metrics:
       changes:
         - rename_metrics:
-            name_map:
-              %s: %s
+            %s: %s
 `
 
 // metricSemconv renders a semconv file declaring a single metric group. The
@@ -181,8 +180,7 @@ versions:
     metrics:
       changes:
         - rename_metrics:
-            name_map:
-              foo: bar
+            foo: bar
   5.0.0:
 `),
 		"1.0.0": metricSemconv("foo", "By", "counter"),

--- a/storage/semconv/storage_rename_validation_test.go
+++ b/storage/semconv/storage_rename_validation_test.go
@@ -159,6 +159,81 @@ func TestRenameEdgeValidation(t *testing.T) {
 	})
 }
 
+// TestAttributeRenameScope checks that an attribute rename restricted by
+// apply_to_metrics does not rewrite the attributes of other metrics. The schema
+// scopes user→tenant to scoped.metric only, so a series of other.metric that
+// carries user must keep it.
+func TestAttributeRenameScope(t *testing.T) {
+	schema := []byte(`file_format: 1.1.0
+schema_url: https://example.com/schemas/1.1.0
+versions:
+  1.0.0:
+  1.1.0:
+    metrics:
+      changes:
+        - rename_attributes:
+            attribute_map:
+              user: tenant
+            apply_to_metrics:
+              - scoped.metric
+`)
+	semconv110 := []byte(`groups:
+  - id: metric.scoped.metric
+    type: metric
+    metric_name: scoped.metric
+    unit: "s"
+    instrument: histogram
+    attributes:
+      - ref: tenant
+  - id: metric.other.metric
+    type: metric
+    metric_name: other.metric
+    unit: "s"
+    instrument: histogram
+    attributes:
+      - ref: tenant
+`)
+
+	underlying := teststorage.New(t)
+	wrapped, err := semconv.AwareStorageWithRegistry(underlying, map[string][]byte{
+		"registry.yaml": schema,
+		"1.1.0":         semconv110,
+	})
+	require.NoError(t, err)
+
+	appendSeries(t, wrapped, "scoped.metric", 1, 1.0, "user", "alice")
+	appendSeries(t, wrapped, "other.metric", 1, 2.0, "user", "bob")
+
+	q, err := wrapped.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	selectMetric := func(name string) map[string]float64 {
+		return collectSeries(t, q.Select(context.Background(), false, nil,
+			labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, name),
+			labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.1.0"),
+			labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+		))
+	}
+
+	// The metric the rename is scoped to still has its historical attribute
+	// normalised to the anchor version's name.
+	got := selectMetric("scoped.metric")
+	require.Len(t, got, 1, "got %v", got)
+	for k := range got {
+		require.Contains(t, k, `tenant="alice"`, "the scoped metric must be normalised")
+	}
+
+	// Any other metric must be left alone. Before apply_to_metrics was honoured,
+	// this attribute was rewritten to tenant as well.
+	got = selectMetric("other.metric")
+	require.Len(t, got, 1, "got %v", got)
+	for k := range got {
+		require.Contains(t, k, `user="bob"`, "a rename scoped to another metric must not apply here")
+		require.NotContains(t, k, "tenant=")
+	}
+}
+
 func TestAmbiguousMetricNameWarns(t *testing.T) {
 	// Two groups declaring the same metric_name: the collision that previously
 	// resolved to whichever group was parsed last, with no warning.

--- a/storage/semconv/storage_rename_validation_test.go
+++ b/storage/semconv/storage_rename_validation_test.go
@@ -115,7 +115,7 @@ func TestRenameEdgeValidation(t *testing.T) {
 
 		require.Empty(t, got, "series of a differently-united metric must not be merged in, got %v", got)
 		requireWarningsContain(t, warnings, "treating them as different metrics")
-		requireWarningsContain(t, warnings, `renames "old.name" to "new.name"`)
+		requireWarningsContain(t, warnings, `links it to "old.name"`)
 	})
 
 	// Same unit, different instrument: a histogram and a counter are not the
@@ -157,6 +157,75 @@ func TestRenameEdgeValidation(t *testing.T) {
 		require.Len(t, got, 1, "expected the series to still merge, got %v", got)
 		requireWarningsContain(t, warnings, "could not be corroborated")
 	})
+}
+
+// TestRecycledMetricName covers the case the schema format cannot express: a
+// metric name that was renamed away and later reused by an unrelated metric.
+//
+//	1.0.0  foo exists, counting bytes
+//	2.0.0  schema renames foo to bar
+//	5.0.0  a new, unrelated metric claims the name foo, measuring seconds
+//
+// Querying foo at 5.0.0 means the new metric. The 2.0.0 rename edge concerns the
+// old foo and must not drag bar's series in. Note that the edge is entirely
+// self-consistent — foo at 1.0.0 and bar at 2.0.0 are both By/counter — so
+// comparing an edge's own two endpoints approves it. Only comparing the hop back
+// to the queried metric catches this.
+func TestRecycledMetricName(t *testing.T) {
+	files := map[string][]byte{
+		"registry.yaml": []byte(`file_format: 1.1.0
+schema_url: https://example.com/schemas/5.0.0
+versions:
+  1.0.0:
+  2.0.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            name_map:
+              foo: bar
+  5.0.0:
+`),
+		"1.0.0": metricSemconv("foo", "By", "counter"),
+		"2.0.0": metricSemconv("bar", "By", "counter"),
+		// 5.0.0 declares both the reused name and the metric the old foo became.
+		"5.0.0": []byte(`groups:
+  - id: metric.foo
+    type: metric
+    metric_name: foo
+    unit: "s"
+    instrument: histogram
+    attributes:
+      - ref: http.response.status_code
+  - id: metric.bar
+    type: metric
+    metric_name: bar
+    unit: "By"
+    instrument: counter
+    attributes:
+      - ref: http.response.status_code
+`),
+	}
+
+	underlying := teststorage.New(t)
+	wrapped, err := semconv.AwareStorageWithRegistry(underlying, files)
+	require.NoError(t, err)
+
+	// Series of the metric the old foo became. Querying today's foo must not
+	// pick these up.
+	appendSeries(t, wrapped, "bar", 1, 7.0, "http.response.status_code", "200")
+
+	q, err := wrapped.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	set := q.Select(context.Background(), false, nil,
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/5.0.0"),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	)
+	got := collectSeries(t, set)
+	require.Empty(t, got, "an unrelated metric that once held this name must not be merged in, got %v", got)
+	requireWarningsContain(t, warningStrings(set.Warnings()), "treating them as different metrics")
 }
 
 // TestAttributeRenameScope checks that an attribute rename restricted by

--- a/storage/semconv/storage_traversal_test.go
+++ b/storage/semconv/storage_traversal_test.go
@@ -1,0 +1,111 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// selectAt runs a fanned-out Select against the embedded registry, anchored at
+// semconv version anchor.
+func selectAt(t *testing.T, s storage.Storage, anchor, metricName string) storage.SeriesSet {
+	t.Helper()
+	q, err := s.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	return q.Select(context.Background(), false, nil,
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, metricName),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/"+anchor),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	)
+}
+
+// TestFanOutReachesEveryEraFromAnyAnchor walks the embedded registry's rename
+// chain (test.counter → test at 1.1.0 → test.v2 at 1.2.0) from every anchor.
+//
+// Anchoring at the newest version happens to work with a truncated walk, because
+// then every rename is on the backward side; the oldest and middle anchors are what
+// expose a walk that mis-slices the version history or fails to chain across the
+// anchor. Each anchor must reach all three eras.
+func TestFanOutReachesEveryEraFromAnyAnchor(t *testing.T) {
+	// eras names the attribute each era's series is expected to carry in the
+	// result: the anchor's own name for it, or the stored one where the anchor
+	// declares no attributes for the queried metric.
+	eras := func(attrs ...string) []string { return attrs }
+
+	for _, tc := range []struct {
+		name        string
+		anchor      string
+		queried     string
+		attrs       []string
+		description string
+	}{
+		{
+			name:        "oldest anchor",
+			anchor:      "1.0.0",
+			queried:     "test.counter",
+			attrs:       eras("user", "user", "user"),
+			description: "no version is at or before 1.0.0, so the whole chain has to be walked forward",
+		},
+		{
+			name:        "middle anchor",
+			anchor:      "1.1.0",
+			queried:     "test",
+			attrs:       eras("tenant", "tenant", "tenant"),
+			description: "1.1.0 is walked backward and 1.2.0 forward",
+		},
+		{
+			name:        "newest anchor",
+			anchor:      "1.2.0",
+			queried:     "test.v2",
+			attrs:       eras("tenant", "tenant", "tenant"),
+			description: "every rename is on the backward side",
+		},
+		{
+			name:    "middle anchor with a name that version renamed away",
+			anchor:  "1.1.0",
+			queried: "test.counter",
+			// Semconv 1.1.0 declares no metric called test.counter, so it supplies
+			// no canonical attribute names and each era keeps the one it stored.
+			attrs: eras("user", "tenant", "tenant"),
+			description: "test.counter is the name 1.1.0 renamed, so the backward walk crosses " +
+				"that rename and the forward walk has to continue from where it landed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped, _ := newAwareStorage(t)
+			// One series per naming era, distinguished by attribute value so the
+			// three stay distinct series rather than merging into one.
+			appendSeries(t, wrapped, "test.counter", 1, 1.0, "user", "a")
+			appendSeries(t, wrapped, "test", 1, 2.0, "tenant", "b")
+			appendSeries(t, wrapped, "test.v2", 1, 3.0, "tenant", "c")
+
+			got := collectSeries(t, selectAt(t, wrapped, tc.anchor, tc.queried))
+
+			require.Len(t, got, 3, "%s: got %v", tc.description, got)
+			for i, value := range []string{"a", "b", "c"} {
+				require.Contains(t, got,
+					labels.FromStrings(model.MetricNameLabel, tc.queried, tc.attrs[i], value).String())
+			}
+		})
+	}
+}

--- a/storage/semconv/testdata/otel_with_chained_renames.yaml
+++ b/storage/semconv/testdata/otel_with_chained_renames.yaml
@@ -6,8 +6,7 @@ versions:
     metrics:
       changes:
         - rename_metrics:
-            name_map:
-              metric.v1: metric.v2
+            metric.v1: metric.v2
         - rename_attributes:
             attribute_map:
               attr.v1: attr.v2
@@ -15,8 +14,7 @@ versions:
     metrics:
       changes:
         - rename_metrics:
-            name_map:
-              metric.v2: metric.v3
+            metric.v2: metric.v3
         - rename_attributes:
             attribute_map:
               attr.v2: attr.v3

--- a/storage/semconv/testdata/otel_with_metric_renames.yaml
+++ b/storage/semconv/testdata/otel_with_metric_renames.yaml
@@ -6,6 +6,5 @@ versions:
     metrics:
       changes:
         - rename_metrics:
-            name_map:
-              old.metric.name: new.metric.name
-              another.old.metric: another.new.metric
+            old.metric.name: new.metric.name
+            another.old.metric: another.new.metric

--- a/storage/semconv/testdata/upstream/schema-1.44.0.yaml
+++ b/storage/semconv/testdata/upstream/schema-1.44.0.yaml
@@ -1,0 +1,768 @@
+
+
+file_format: 1.1.0
+schema_url: https://opentelemetry.io/schemas/1.44.0
+versions:
+  1.44.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            container.memory.paging.faults: container.paging.faults
+            k8s.node.memory.paging.faults: k8s.node.paging.faults
+            k8s.pod.memory.paging.faults: k8s.pod.paging.faults
+  1.43.0:
+  1.42.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            v8js.memory.heap.limit: v8js.memory.heap.space.size
+  1.41.1:
+  1.41.0:
+    metrics:
+      changes:
+        - rename_metrics:
+            k8s.container.cpu.limit: k8s.container.cpu.limit.desired
+            k8s.container.cpu.limit_utilization: k8s.container.cpu.limit.utilization
+            k8s.container.cpu.request: k8s.container.cpu.request.desired
+            k8s.container.cpu.request_utilization: k8s.container.cpu.request.utilization
+            k8s.container.memory.limit: k8s.container.memory.limit.desired
+            k8s.container.memory.request: k8s.container.memory.request.desired
+  1.40.0:
+    all:
+      changes:
+        - rename_attributes:
+            attribute_map:
+              feature_flag.evaluation.error.message: feature_flag.error.message
+    metrics:
+      changes:
+        - rename_metrics:
+            system.memory.shared: system.memory.linux.shared
+  1.39.0:
+    all:
+      changes:
+        - rename_attributes:
+            attribute_map:
+              linux.memory.slab.state: system.memory.linux.slab.state
+              peer.service: service.peer.name
+              rpc.connect_rpc.error_code: rpc.response.status_code
+              rpc.connect_rpc.request.metadata: rpc.request.metadata
+              rpc.connect_rpc.response.metadata: rpc.response.metadata
+              rpc.grpc.request.metadata: rpc.request.metadata
+              rpc.grpc.response.metadata: rpc.response.metadata
+              rpc.jsonrpc.request_id: jsonrpc.request.id
+              rpc.jsonrpc.version: jsonrpc.protocol.version
+              rpc.system: rpc.system.name
+    metrics:
+      changes:
+        - rename_metrics:
+            process.open_file_descriptor.count: process.unix.file_descriptor.count
+            system.linux.memory.available: system.memory.linux.available
+            system.linux.memory.slab.usage: system.memory.linux.slab.usage
+  1.38.0:
+    all:
+      changes:
+        - rename_attributes:
+            attribute_map:
+              process.context_switch_type: process.context_switch.type
+              process.paging.fault_type: system.paging.fault.type
+              system.cpu.logical_number: cpu.logical_number
+              system.paging.type: system.paging.fault.type
+              system.process.status: process.state
+              system.processes.status: process.state
+    metrics:
+      changes:
+        - rename_metrics:
+            k8s.cronjob.active_jobs: k8s.cronjob.job.active
+            k8s.daemonset.current_scheduled_nodes: k8s.daemonset.node.current_scheduled
+            k8s.daemonset.desired_scheduled_nodes: k8s.daemonset.node.desired_scheduled
+            k8s.daemonset.misscheduled_nodes: k8s.daemonset.node.misscheduled
+            k8s.daemonset.ready_nodes: k8s.daemonset.node.ready
+            k8s.deployment.available_pods: k8s.deployment.pod.available
+            k8s.deployment.desired_pods: k8s.deployment.pod.desired
+            k8s.hpa.current_pods: k8s.hpa.pod.current
+            k8s.hpa.desired_pods: k8s.hpa.pod.desired
+            k8s.hpa.max_pods: k8s.hpa.pod.max
+            k8s.hpa.min_pods: k8s.hpa.pod.min
+            k8s.job.active_pods: k8s.job.pod.active
+            k8s.job.desired_successful_pods: k8s.job.pod.desired_successful
+            k8s.job.failed_pods: k8s.job.pod.failed
+            k8s.job.max_parallel_pods: k8s.job.pod.max_parallel
+            k8s.job.successful_pods: k8s.job.pod.successful
+            k8s.node.allocatable.cpu: k8s.node.cpu.allocatable
+            k8s.node.allocatable.ephemeral_storage: k8s.node.ephemeral_storage.allocatable
+            k8s.node.allocatable.memory: k8s.node.memory.allocatable
+            k8s.node.allocatable.pods: k8s.node.pod.allocatable
+            k8s.replicaset.available_pods: k8s.replicaset.pod.available
+            k8s.replicaset.desired_pods: k8s.replicaset.pod.desired
+            k8s.replication_controller.available_pods: k8s.replicationcontroller.pod.available
+            k8s.replication_controller.desired_pods: k8s.replicationcontroller.pod.desired
+            k8s.replicationcontroller.available_pods: k8s.replicationcontroller.pod.available
+            k8s.replicationcontroller.desired_pods: k8s.replicationcontroller.pod.desired
+            k8s.statefulset.current_pods: k8s.statefulset.pod.current
+            k8s.statefulset.desired_pods: k8s.statefulset.pod.desired
+            k8s.statefulset.ready_pods: k8s.statefulset.pod.ready
+            k8s.statefulset.updated_pods: k8s.statefulset.pod.updated
+            v8js.heap.space.available_size: v8js.memory.heap.space.available_size
+            v8js.heap.space.physical_size: v8js.memory.heap.space.physical_size
+  1.37.0:
+    all:
+      changes:
+        - rename_attributes:
+            attribute_map:
+              android.state: android.app.state
+              container.runtime: container.runtime.name
+              enduser.role: user.roles
+              gen_ai.openai.request.service_tier: openai.request.service_tier
+              gen_ai.openai.response.service_tier: openai.response.service_tier
+              gen_ai.openai.response.system_fingerprint: openai.response.system_fingerprint
+              gen_ai.system: gen_ai.provider.name
+              ios.state: ios.app.state
+  1.36.0:
+  1.35.0:
+    all:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1698
+        - rename_attributes:
+            attribute_map:
+              az.namespace: azure.resource_provider.namespace
+              az.service_request_id: azure.service.request.id
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/issues/1800
+        - rename_metrics:
+            system.network.connections: system.network.connection.count
+  1.34.0:
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/2295
+        - rename_metrics:
+            cpu.time: system.cpu.time
+            cpu.utilization: system.cpu.utilization
+            cpu.frequency: system.cpu.frequency
+  1.33.0:
+    all:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1982
+        - rename_attributes:
+            attribute_map:
+              feature_flag.provider_name: feature_flag.provider.name
+        # https://github.com/open-telemetry/semantic-conventions/pull/1994
+        - rename_attributes:
+            attribute_map:
+              feature_flag.evaluation.error.message: error.message
+  1.32.0:
+    all:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1989
+        - rename_attributes:
+            attribute_map:
+              feature_flag.evaluation.reason: feature_flag.result.reason
+              feature_flag.variant: feature_flag.result.variant
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/2042
+        - rename_metrics:
+            otel.sdk.span.live.count: otel.sdk.span.live
+            otel.sdk.span.ended.count: otel.sdk.span.ended
+            otel.sdk.processor.span.processed.count: otel.sdk.processor.span.processed
+            otel.sdk.exporter.span.inflight.count: otel.sdk.exporter.span.inflight
+            otel.sdk.exporter.span.exported.count: otel.sdk.exporter.span.exported
+  1.31.0:
+    all:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1880
+        - rename_attributes:
+            attribute_map:
+              android.state: android.app.state
+              io.state: ios.app.state
+    metrics:
+      changes:
+        - rename_metrics:
+            k8s.replication_controller.desired_pods: k8s.replicationcontroller.desired_pods
+            k8s.replication_controller.available_pods: k8s.replicationcontroller.available_pods
+        # https://github.com/open-telemetry/semantic-conventions/pull/1896
+        - rename_metrics:
+            system.cpu.time: cpu.time
+            system.cpu.utilization: cpu.utilization
+            system.cpu.frequency: cpu.frequency
+        # https://github.com/open-telemetry/semantic-conventions/pull/1896
+        - rename_attributes:
+            attribute_map:
+              system.cpu.logical_number: cpu.logical_number
+  1.30.0:
+    all:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1632
+        - rename_attributes:
+            attribute_map:
+              gen_ai.openai.request.seed: gen_ai.request.seed
+              system.network.state: network.connection.state
+        # https://github.com/open-telemetry/semantic-conventions/pull/1624
+        - rename_attributes:
+            attribute_map:
+              code.function: code.function.name
+              code.filepath: code.file.path
+              code.lineno: code.line.number
+              code.column: code.column.number
+        # https://github.com/open-telemetry/semantic-conventions/pull/1734
+        - rename_attributes:
+            attribute_map:
+              db.system: db.system.name
+              db.cassandra.coordinator.dc: cassandra.coordinator.dc
+              db.cassandra.coordinator.id: cassandra.coordinator.id
+              db.cassandra.consistency_level: cassandra.consistency.level
+              db.cassandra.idempotence: cassandra.query.idempotent
+              db.cassandra.page_size: cassandra.page.size
+              db.cassandra.speculative_execution_count: cassandra.speculative_execution.count
+              db.cosmosdb.client_id: azure.client.id
+              db.cosmosdb.connection_mode: azure.cosmosdb.connection.mode
+              db.cosmosdb.consistency_level: azure.cosmosdb.consistency.level
+              db.cosmosdb.request_charge: azure.cosmosdb.operation.request_charge
+              db.cosmosdb.request_content_length: azure.cosmosdb.request.body.size
+              db.cosmosdb.regions_contacted: azure.cosmosdb.operation.contacted_regions
+              db.cosmosdb.sub_status_code: azure.cosmosdb.response.sub_status_code
+              db.elasticsearch.node.name: elasticsearch.node.name
+              # db.elasticsearch.path_parts is a template attribute, schema transformation
+              # does not support it, adding as a comment for consistency
+              # db.elasticsearch.path_parts.<key> -> db.operation.parameter.<key>
+    metrics:
+      changes:
+        - rename_metrics:
+            db.client.cosmosdb.operation.request_charge: azure.cosmosdb.client.operation.request_charge
+            db.client.cosmosdb.active_instance.count: azure.cosmosdb.client.active_instance.count
+
+  1.29.0:
+    all:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1520
+        - rename_attributes:
+            attribute_map:
+              process.executable.build_id.profiling: process.executable.build_id.htlhash
+        # https://github.com/open-telemetry/semantic-conventions/pull/1383
+        - rename_attributes:
+            attribute_map:
+              vcs.repository.change.id: vcs.change.id
+              vcs.repository.change.title: vcs.change.title
+              vcs.repository.ref.name: vcs.ref.head.name
+              vcs.repository.ref.revision: vcs.ref.head.revision
+              vcs.repository.ref.type: vcs.ref.head.type
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1492
+        - rename_attributes:
+            attribute_map:
+              system.device: network.interface.name
+            apply_to_metrics:
+              - container.network.io
+              - system.network.dropped
+              - system.network.errors
+              - system.network.io
+              - system.network.connections
+  1.28.0:
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1422
+        - rename_metrics:
+            messaging.client.published.messages: messaging.client.sent.messages
+  1.27.0:
+    all:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1216
+        - rename_attributes:
+            attribute_map:
+              tls.client.server_name: server.address
+        # https://github.com/open-telemetry/semantic-conventions/pull/1075
+        - rename_attributes:
+            attribute_map:
+              deployment.environment: deployment.environment.name
+        # https://github.com/open-telemetry/semantic-conventions/pull/1245
+        - rename_attributes:
+            attribute_map:
+              messaging.kafka.message.offset: messaging.kafka.offset
+        # https://github.com/open-telemetry/semantic-conventions/pull/815
+        - rename_attributes:
+            attribute_map:
+              messaging.kafka.consumer.group: messaging.consumer.group.name
+              messaging.rocketmq.client_group: messaging.consumer.group.name
+              messaging.eventhubs.consumer.group: messaging.consumer.group.name
+              messaging.servicebus.destination.subscription_name: messaging.destination.subscription.name
+        # https://github.com/open-telemetry/semantic-conventions/pull/1200
+        - rename_attributes:
+            attribute_map:
+              gen_ai.usage.completion_tokens: gen_ai.usage.output_tokens
+              gen_ai.usage.prompt_tokens: gen_ai.usage.input_tokens
+    spans:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1002
+        - rename_attributes:
+            attribute_map:
+              db.elasticsearch.cluster.name: db.namespace
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/1125
+        - rename_attributes:
+            attribute_map:
+              db.client.connections.state: db.client.connection.state
+            apply_to_metrics:
+              - db.client.connection.count
+        - rename_attributes:
+            attribute_map:
+              db.client.connections.pool.name: db.client.connection.pool.name
+            apply_to_metrics:
+              - db.client.connection.count
+              - db.client.connection.idle.max
+              - db.client.connection.idle.min
+              - db.client.connection.max
+              - db.client.connection.pending_requests
+              - db.client.connection.timeouts
+              - db.client.connection.create_time
+              - db.client.connection.wait_time
+              - db.client.connection.use_time
+        # https://github.com/open-telemetry/semantic-conventions/pull/1006
+        - rename_metrics:
+            messaging.publish.messages: messaging.client.published.messages
+        # https://github.com/open-telemetry/semantic-conventions/pull/1026
+        - rename_attributes:
+            attribute_map:
+              system.cpu.state: cpu.mode
+              process.cpu.state: cpu.mode
+              container.cpu.state: cpu.mode
+            apply_to_metrics:
+              - system.cpu.time
+              - system.cpu.utilization
+              - process.cpu.time
+              - process.cpu.utilization
+              - container.cpu.time
+        # https://github.com/open-telemetry/semantic-conventions/pull/1265
+        - rename_metrics:
+            jvm.buffer.memory.usage: jvm.buffer.memory.used
+  1.26.0:
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/966
+        - rename_metrics:
+            db.client.connections.usage: db.client.connection.count
+            db.client.connections.idle.max: db.client.connection.idle.max
+            db.client.connections.idle.min: db.client.connection.idle.min
+            db.client.connections.max: db.client.connection.max
+            db.client.connections.pending_requests: db.client.connection.pending_requests
+            db.client.connections.timeouts: db.client.connection.timeouts
+        # https://github.com/open-telemetry/semantic-conventions/pull/948
+        - rename_attributes:
+            attribute_map:
+              messaging.client_id: messaging.client.id
+        # https://github.com/open-telemetry/semantic-conventions/pull/909
+        - rename_attributes:
+            attribute_map:
+              state: db.client.connections.state
+            apply_to_metrics:
+              - db.client.connections.usage
+        - rename_attributes:
+            attribute_map:
+              pool.name: db.client.connections.pool.name
+            apply_to_metrics:
+              - db.client.connections.usage
+              - db.client.connections.idle.max
+              - db.client.connections.idle.min
+              - db.client.connections.max
+              - db.client.connections.pending_requests
+              - db.client.connections.timeouts
+              - db.client.connections.create_time
+              - db.client.connections.wait_time
+              - db.client.connections.use_time
+    all:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/731
+        - rename_attributes:
+            attribute_map:
+              enduser.id: user.id
+
+  1.25.0:
+    spans:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/911
+        - rename_attributes:
+            attribute_map:
+              db.name: db.namespace
+        # https://github.com/open-telemetry/semantic-conventions/pull/870
+        - rename_attributes:
+            attribute_map:
+              db.sql.table: db.collection.name
+              db.mongodb.collection: db.collection.name
+              db.cosmosdb.container: db.collection.name
+              db.cassandra.table: db.collection.name
+        # https://github.com/open-telemetry/semantic-conventions/pull/798
+        - rename_attributes:
+            attribute_map:
+              messaging.kafka.destination.partition: messaging.destination.partition.id
+        # https://github.com/open-telemetry/semantic-conventions/pull/875
+        - rename_attributes:
+            attribute_map:
+              db.operation: db.operation.name
+        # https://github.com/open-telemetry/semantic-conventions/pull/913
+        - rename_attributes:
+            attribute_map:
+              messaging.operation: messaging.operation.type
+        # https://github.com/open-telemetry/semantic-conventions/pull/866
+        - rename_attributes:
+            attribute_map:
+              db.statement: db.query.text
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/484
+        - rename_attributes:
+            attribute_map:
+              system.processes.status: system.process.status
+            apply_to_metrics:
+              - system.processes.count
+        - rename_metrics:
+            system.processes.count: system.process.count
+            system.processes.created: system.process.created
+        # https://github.com/open-telemetry/semantic-conventions/pull/625
+        - rename_attributes:
+            attribute_map:
+              container.labels: container.label
+              k8s.pod.labels: k8s.pod.label
+        # https://github.com/open-telemetry/semantic-conventions/pull/330
+        - rename_metrics:
+            process.threads: process.thread.count
+            process.open_file_descriptors: process.open_file_descriptor.count
+        - rename_attributes:
+            attribute_map:
+              state: process.cpu.state
+            apply_to_metrics:
+              - process.cpu.time
+              - process.cpu.utilization
+        - rename_attributes:
+            attribute_map:
+              direction: disk.io.direction
+            apply_to_metrics:
+              - process.disk.io
+        - rename_attributes:
+            attribute_map:
+              type: process.context_switch_type
+            apply_to_metrics:
+              - process.context_switches
+        - rename_attributes:
+            attribute_map:
+              direction: network.io.direction
+            apply_to_metrics:
+              - process.network.io
+        - rename_attributes:
+            attribute_map:
+              type: process.paging.fault_type
+            apply_to_metrics:
+              - process.paging.faults
+    all:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/854
+        - rename_attributes:
+            attribute_map:
+              message.type: rpc.message.type
+              message.id: rpc.message.id
+              message.compressed_size: rpc.message.compressed_size
+              message.uncompressed_size: rpc.message.uncompressed_size
+
+  1.24.0:
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/536
+        - rename_metrics:
+            jvm.memory.usage: jvm.memory.used
+            jvm.memory.usage_after_last_gc: jvm.memory.used_after_last_gc
+        # https://github.com/open-telemetry/semantic-conventions/pull/530
+        - rename_attributes:
+            attribute_map:
+              system.network.io.direction: network.io.direction
+              system.disk.io.direction: disk.io.direction
+  1.23.1:
+  1.23.0:
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/20
+        - rename_attributes:
+            attribute_map:
+              thread.daemon: jvm.thread.daemon
+            apply_to_metrics:
+              - jvm.thread.count
+  1.22.0:
+    spans:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/229
+        - rename_attributes:
+            attribute_map:
+              messaging.message.payload_size_bytes: messaging.message.body.size
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/374
+        - rename_attributes:
+            attribute_map:
+              http.resend_count: http.request.resend_count
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/224
+        - rename_metrics:
+            http.client.duration: http.client.request.duration
+            http.server.duration: http.server.request.duration
+        # https://github.com/open-telemetry/semantic-conventions/pull/241
+        - rename_metrics:
+            process.runtime.jvm.memory.usage: jvm.memory.usage
+            process.runtime.jvm.memory.committed: jvm.memory.committed
+            process.runtime.jvm.memory.limit: jvm.memory.limit
+            process.runtime.jvm.memory.usage_after_last_gc: jvm.memory.usage_after_last_gc
+            process.runtime.jvm.gc.duration: jvm.gc.duration
+            # also https://github.com/open-telemetry/semantic-conventions/pull/252
+            process.runtime.jvm.threads.count: jvm.thread.count
+            # also https://github.com/open-telemetry/semantic-conventions/pull/252
+            process.runtime.jvm.classes.loaded: jvm.class.loaded
+            # also https://github.com/open-telemetry/semantic-conventions/pull/252
+            process.runtime.jvm.classes.unloaded: jvm.class.unloaded
+            # also https://github.com/open-telemetry/semantic-conventions/pull/252
+            # and https://github.com/open-telemetry/semantic-conventions/pull/60
+            process.runtime.jvm.classes.current_loaded: jvm.class.count
+            process.runtime.jvm.cpu.time: jvm.cpu.time
+            process.runtime.jvm.cpu.recent_utilization: jvm.cpu.recent_utilization
+            process.runtime.jvm.memory.init: jvm.memory.init
+            process.runtime.jvm.system.cpu.utilization: jvm.system.cpu.utilization
+            process.runtime.jvm.system.cpu.load_1m: jvm.system.cpu.load_1m
+            # https://github.com/open-telemetry/semantic-conventions/pull/253
+            process.runtime.jvm.buffer.usage: jvm.buffer.memory.usage
+            # https://github.com/open-telemetry/semantic-conventions/pull/253
+            process.runtime.jvm.buffer.limit: jvm.buffer.memory.limit
+            process.runtime.jvm.buffer.count: jvm.buffer.count
+        # https://github.com/open-telemetry/semantic-conventions/pull/20
+        - rename_attributes:
+            attribute_map:
+              type: jvm.memory.type
+              pool: jvm.memory.pool.name
+            apply_to_metrics:
+              - jvm.memory.usage
+              - jvm.memory.committed
+              - jvm.memory.limit
+              - jvm.memory.usage_after_last_gc
+              - jvm.memory.init
+        - rename_attributes:
+            attribute_map:
+              name: jvm.gc.name
+              action: jvm.gc.action
+            apply_to_metrics:
+              - jvm.gc.duration
+        - rename_attributes:
+            attribute_map:
+              daemon: thread.daemon
+            apply_to_metrics:
+              - jvm.threads.count
+        - rename_attributes:
+            attribute_map:
+              pool: jvm.buffer.pool.name
+            apply_to_metrics:
+              - jvm.buffer.memory.usage
+              - jvm.buffer.memory.limit
+              - jvm.buffer.count
+        # https://github.com/open-telemetry/semantic-conventions/pull/89
+        - rename_attributes:
+            attribute_map:
+              state: system.cpu.state
+              cpu: system.cpu.logical_number
+            apply_to_metrics:
+              - system.cpu.time
+              - system.cpu.utilization
+        - rename_attributes:
+            attribute_map:
+              state: system.memory.state
+            apply_to_metrics:
+              - system.memory.usage
+              - system.memory.utilization
+        - rename_attributes:
+            attribute_map:
+              state: system.paging.state
+            apply_to_metrics:
+              - system.paging.usage
+              - system.paging.utilization
+        - rename_attributes:
+            attribute_map:
+              type: system.paging.type
+              direction: system.paging.direction
+            apply_to_metrics:
+              - system.paging.faults
+              - system.paging.operations
+        - rename_attributes:
+            attribute_map:
+              device: system.device
+              direction: system.disk.direction
+            apply_to_metrics:
+              - system.disk.io
+              - system.disk.operations
+              - system.disk.io_time
+              - system.disk.operation_time
+              - system.disk.merged
+        - rename_attributes:
+            attribute_map:
+              device: system.device
+              state: system.filesystem.state
+              type: system.filesystem.type
+              mode: system.filesystem.mode
+              mountpoint: system.filesystem.mountpoint
+            apply_to_metrics:
+              - system.filesystem.usage
+              - system.filesystem.utilization
+        - rename_attributes:
+            attribute_map:
+              device: system.device
+              direction: system.network.direction
+              protocol: network.protocol
+              state: system.network.state
+            apply_to_metrics:
+              - system.network.dropped
+              - system.network.packets
+              - system.network.errors
+              - system.network.io
+              - system.network.connections
+        - rename_attributes:
+            attribute_map:
+              status: system.processes.status
+            apply_to_metrics:
+              - system.processes.count
+        # https://github.com/open-telemetry/semantic-conventions/pull/247
+        - rename_metrics:
+            http.server.request.size: http.server.request.body.size
+            http.server.response.size: http.server.response.body.size
+    resources:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/178
+        - rename_attributes:
+            attribute_map:
+              telemetry.auto.version: telemetry.distro.version
+  1.21.0:
+    spans:
+      changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3336
+        - rename_attributes:
+            attribute_map:
+              messaging.kafka.client_id: messaging.client_id
+              messaging.rocketmq.client_id: messaging.client_id
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3402
+        - rename_attributes:
+            attribute_map:
+              # net.peer.(name|port) attributes were usually populated on client side
+              # so they should be usually translated to server.(address|port)
+              # net.host.* attributes were only populated on server side
+              net.host.name: server.address
+              net.host.port: server.port
+              # was only populated on client side
+              net.sock.peer.name: server.socket.domain
+              # net.sock.peer.(addr|port) mapping is not possible
+              # since they applied to both client and server side
+              # were only populated on server side
+              net.sock.host.addr: server.socket.address
+              net.sock.host.port: server.socket.port
+              http.client_ip: client.address
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3426
+        - rename_attributes:
+            attribute_map:
+              net.protocol.name: network.protocol.name
+              net.protocol.version: network.protocol.version
+              net.host.connection.type: network.connection.type
+              net.host.connection.subtype: network.connection.subtype
+              net.host.carrier.name: network.carrier.name
+              net.host.carrier.mcc: network.carrier.mcc
+              net.host.carrier.mnc: network.carrier.mnc
+              net.host.carrier.icc: network.carrier.icc
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3355
+        - rename_attributes:
+            attribute_map:
+              http.method: http.request.method
+              http.status_code: http.response.status_code
+              http.scheme: url.scheme
+              http.url: url.full
+              http.request_content_length: http.request.body.size
+              http.response_content_length: http.response.body.size
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/53
+        - rename_metrics:
+            process.runtime.jvm.cpu.utilization: process.runtime.jvm.cpu.recent_utilization
+  1.20.0:
+    spans:
+      changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3272
+        - rename_attributes:
+            attribute_map:
+              net.app.protocol.name: net.protocol.name
+              net.app.protocol.version: net.protocol.version
+  1.19.0:
+    spans:
+      changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3209
+        - rename_attributes:
+            attribute_map:
+              faas.execution: faas.invocation_id
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3188
+        - rename_attributes:
+            attribute_map:
+              faas.id: cloud.resource_id
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3190
+        - rename_attributes:
+            attribute_map:
+              http.user_agent: user_agent.original
+    resources:
+      changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3190
+        - rename_attributes:
+            attribute_map:
+              browser.user_agent: user_agent.original
+  1.18.0:
+  1.17.0:
+    spans:
+      changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/2957
+        - rename_attributes:
+            attribute_map:
+              messaging.consumer_id: messaging.consumer.id
+              messaging.protocol: net.app.protocol.name
+              messaging.protocol_version: net.app.protocol.version
+              messaging.destination: messaging.destination.name
+              messaging.temp_destination: messaging.destination.temporary
+              messaging.destination_kind: messaging.destination.kind
+              messaging.message_id: messaging.message.id
+              messaging.conversation_id: messaging.message.conversation_id
+              messaging.message_payload_size_bytes: messaging.message.payload_size_bytes
+              messaging.message_payload_compressed_size_bytes: messaging.message.payload_compressed_size_bytes
+              messaging.rabbitmq.routing_key: messaging.rabbitmq.destination.routing_key
+              messaging.kafka.message_key: messaging.kafka.message.key
+              messaging.kafka.partition: messaging.kafka.destination.partition
+              messaging.kafka.tombstone: messaging.kafka.message.tombstone
+              messaging.rocketmq.message_type: messaging.rocketmq.message.type
+              messaging.rocketmq.message_tag: messaging.rocketmq.message.tag
+              messaging.rocketmq.message_keys: messaging.rocketmq.message.keys
+              messaging.kafka.consumer_group: messaging.kafka.consumer.group
+  1.16.0:
+  1.15.0:
+    spans:
+      changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/2743
+        - rename_attributes:
+            attribute_map:
+              http.retry_count: http.resend_count
+  1.14.0:
+  1.13.0:
+    spans:
+      changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/2614
+        - rename_attributes:
+            attribute_map:
+              net.peer.ip: net.sock.peer.addr
+              net.host.ip: net.sock.host.addr
+  1.12.0:
+  1.11.0:
+  1.10.0:
+  1.9.0:
+  1.8.0:
+    spans:
+      changes:
+        - rename_attributes:
+            attribute_map:
+              db.cassandra.keyspace: db.name
+              db.hbase.namespace: db.name
+  1.7.0:
+  1.6.1:
+  1.5.0:
+  1.4.0:

--- a/storage/semconv/testdata/upstream/semconv-1.21.0.yaml
+++ b/storage/semconv/testdata/upstream/semconv-1.21.0.yaml
@@ -1,0 +1,90 @@
+# Verbatim excerpt of the metric groups from
+#   open-telemetry/semantic-conventions v1.21.0 : model/metrics/http.yaml
+# Kept unmodified so the parser and rename validation are exercised against
+# real semantic-conventions data rather than hand-written fixtures.
+groups:
+  - id: metric.http.server.duration
+    type: metric
+    metric_name: http.server.duration
+    brief: "Measures the duration of inbound HTTP requests."
+    instrument: histogram
+    unit: "s"
+    extends: metric_attributes.http.server
+
+  - id: metric.http.server.active_requests
+    type: metric
+    metric_name: http.server.active_requests
+    brief: "Measures the number of concurrent HTTP requests that are currently in-flight."
+    instrument: updowncounter
+    unit: "{request}"
+    attributes:
+      - ref: http.request.method
+      - ref: url.scheme
+        requirement_level: required
+        examples: ["http", "https"]
+      - ref: server.address
+        requirement_level: opt_in
+        brief: >
+          Name of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
+            include host identifier.
+          - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Host identifier of the `Host` header
+
+          SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
+
+      - ref: server.port
+        requirement_level: opt_in
+        brief: >
+          Port of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
+          - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Port identifier of the `Host` header
+
+  - id: metric.http.server.request.size
+    type: metric
+    metric_name: http.server.request.size
+    brief: "Measures the size of HTTP request messages (compressed)."
+    instrument: histogram
+    unit: "By"
+    extends: metric_attributes.http.server
+
+  - id: metric.http.server.response.size
+    type: metric
+    metric_name: http.server.response.size
+    brief: "Measures the size of HTTP response messages (compressed)."
+    instrument: histogram
+    unit: "By"
+    extends: metric_attributes.http.server
+
+  - id: metric.http.client.duration
+    type: metric
+    metric_name: http.client.duration
+    brief: "Measures the duration of outbound HTTP requests."
+    instrument: histogram
+    unit: "s"
+    extends: metric_attributes.http.client
+
+  - id: metric.http.client.request.size
+    type: metric
+    metric_name: http.client.request.size
+    brief: "Measures the size of HTTP request messages (compressed)."
+    instrument: histogram
+    unit: "By"
+    extends: metric_attributes.http.client
+
+  - id: metric.http.client.response.size
+    type: metric
+    metric_name: http.client.response.size
+    brief: "Measures the size of HTTP response messages (compressed)."
+    instrument: histogram
+    unit: "By"
+    extends: metric_attributes.http.client

--- a/storage/semconv/testdata/upstream/semconv-1.22.0.yaml
+++ b/storage/semconv/testdata/upstream/semconv-1.22.0.yaml
@@ -1,0 +1,107 @@
+# Verbatim excerpt of the metric groups from
+#   open-telemetry/semantic-conventions v1.22.0 : model/metrics/http.yaml
+# Kept unmodified so the parser and rename validation are exercised against
+# real semantic-conventions data rather than hand-written fixtures.
+groups:
+  - id: metric.http.server.request.duration
+    type: metric
+    metric_name: http.server.request.duration
+    brief: "Duration of HTTP server requests."
+    instrument: histogram
+    unit: "s"
+    extends: metric_attributes.http.server
+
+  - id: metric.http.server.active_requests
+    type: metric
+    metric_name: http.server.active_requests
+    brief: "Number of active HTTP server requests."
+    instrument: updowncounter
+    unit: "{request}"
+    attributes:
+      - ref: http.request.method
+        requirement_level: required
+      - ref: url.scheme
+        requirement_level: required
+        examples: ["http", "https"]
+      - ref: server.address
+        requirement_level: opt_in
+        brief: >
+          Name of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
+            include host identifier.
+          - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Host identifier of the `Host` header
+
+          SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
+
+      - ref: server.port
+        requirement_level: opt_in
+        brief: >
+          Port of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
+          - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Port identifier of the `Host` header
+
+  - id: metric.http.server.request.body.size
+    type: metric
+    metric_name: http.server.request.body.size
+    brief: "Size of HTTP server request bodies."
+    instrument: histogram
+    unit: "By"
+    note: >
+      The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and
+      is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
+      header. For requests using transport encoding, this should be the compressed size.
+    extends: metric_attributes.http.server
+
+  - id: metric.http.server.response.body.size
+    type: metric
+    metric_name: http.server.response.body.size
+    brief: "Size of HTTP server response bodies."
+    instrument: histogram
+    unit: "By"
+    note: >
+      The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and
+      is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
+      header. For requests using transport encoding, this should be the compressed size.
+    extends: metric_attributes.http.server
+
+  - id: metric.http.client.request.duration
+    type: metric
+    metric_name: http.client.request.duration
+    brief: "Duration of HTTP client requests."
+    instrument: histogram
+    unit: "s"
+    extends: metric_attributes.http.client
+
+  - id: metric.http.client.request.body.size
+    type: metric
+    metric_name: http.client.request.body.size
+    brief: "Size of HTTP client request bodies."
+    instrument: histogram
+    unit: "By"
+    note: >
+      The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and
+      is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
+      header. For requests using transport encoding, this should be the compressed size.
+    extends: metric_attributes.http.client
+
+  - id: metric.http.client.response.body.size
+    type: metric
+    metric_name: http.client.response.body.size
+    brief: "Size of HTTP client response bodies."
+    instrument: histogram
+    unit: "By"
+    note: >
+      The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and
+      is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
+      header. For requests using transport encoding, this should be the compressed size.
+    extends: metric_attributes.http.client

--- a/storage/semconv/upstream_golden_test.go
+++ b/storage/semconv/upstream_golden_test.go
@@ -34,6 +34,13 @@ import (
 // the file format does not have: every fixture agreed with the bug, so the tests
 // passed while metric renames silently did nothing on real data. These tests
 // exist so the real file format is what the parser is held to.
+//
+// Attribute-rename scoping is deliberately not covered from these artefacts. Real
+// http metric groups declare their attributes with extends (see
+// TestUpstreamSemconvAttributes), which the loader does not resolve, so such a
+// metric has no attributes to rename and any assertion about scoping here would
+// hold no matter what the scoping code did. The hand-written fixtures in
+// storage_rename_validation_test.go and otel_schema_test.go cover it instead.
 const (
 	upstreamSchema        = "./testdata/upstream/schema-1.44.0.yaml"
 	upstreamSemconv1_21_0 = "./testdata/upstream/semconv-1.21.0.yaml"
@@ -91,33 +98,4 @@ func TestUpstreamSchemaMetricRenames(t *testing.T) {
 	// corroborated and nothing is reported.
 	require.Empty(t, warningStrings(set.Warnings()),
 		"a rename corroborated by the real semconv files must not warn")
-}
-
-// TestUpstreamSchemaAttributeRenameScope checks apply_to_metrics against the real
-// schema. Version 1.23.0 renames thread.daemon to jvm.thread.daemon for
-// jvm.thread.count only, so an unrelated metric must not have that attribute
-// rewritten.
-func TestUpstreamSchemaAttributeRenameScope(t *testing.T) {
-	underlying := teststorage.New(t)
-	wrapped, err := semconv.AwareStorageWithRegistry(underlying, upstreamRegistry(t))
-	require.NoError(t, err)
-
-	appendSeries(t, wrapped, "http.server.request.duration", 1, 7.0, "thread.daemon", "true")
-
-	q, err := wrapped.Querier(0, 10)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = q.Close() })
-
-	set := q.Select(context.Background(), false, nil,
-		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "http.server.request.duration"),
-		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.22.0"),
-		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
-	)
-	got := collectSeries(t, set)
-	require.Len(t, got, 1, "got %v", got)
-	for k := range got {
-		require.Contains(t, k, `"thread.daemon"="true"`,
-			"a rename scoped to jvm.thread.count must not rewrite this metric's attribute")
-		require.NotContains(t, k, "jvm.thread.daemon")
-	}
 }

--- a/storage/semconv/upstream_golden_test.go
+++ b/storage/semconv/upstream_golden_test.go
@@ -1,0 +1,123 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage/semconv"
+	"github.com/prometheus/prometheus/util/teststorage"
+)
+
+// The files under testdata/upstream are real artefacts from
+// open-telemetry/semantic-conventions v1.44.0 (commit e10a930), kept unmodified.
+// Hand-written fixtures are free to encode whatever shape the parser happens to
+// expect, which is how rename_metrics came to be read from a name_map key that
+// the file format does not have: every fixture agreed with the bug, so the tests
+// passed while metric renames silently did nothing on real data. These tests
+// exist so the real file format is what the parser is held to.
+const (
+	upstreamSchema        = "./testdata/upstream/schema-1.44.0.yaml"
+	upstreamSemconv1_21_0 = "./testdata/upstream/semconv-1.21.0.yaml"
+	upstreamSemconv1_22_0 = "./testdata/upstream/semconv-1.22.0.yaml"
+)
+
+// upstreamRegistry assembles the real artefacts into a registry, keyed the way
+// AwareStorageWithRegistry expects: semver base names for semconv files, anything
+// else for the schema.
+func upstreamRegistry(t *testing.T) map[string][]byte {
+	t.Helper()
+	read := func(path string) []byte {
+		b, err := os.ReadFile(filepath.Clean(path))
+		require.NoError(t, err)
+		return b
+	}
+	return map[string][]byte{
+		"registry.yaml": read(upstreamSchema),
+		"1.21.0":        read(upstreamSemconv1_21_0),
+		"1.22.0":        read(upstreamSemconv1_22_0),
+	}
+}
+
+// TestUpstreamSchemaMetricRenames guards the file format itself. Reading
+// rename_metrics from a nested name_map key yielded zero metric renames from
+// every real schema while all fixtures still passed, so assert against the real
+// artefact that metric renames are found at all.
+func TestUpstreamSchemaMetricRenames(t *testing.T) {
+	underlying := teststorage.New(t)
+	wrapped, err := semconv.AwareStorageWithRegistry(underlying, upstreamRegistry(t))
+	require.NoError(t, err)
+
+	// http.server.duration was renamed to http.server.request.duration in
+	// semconv 1.22.0, the canonical example of a metric rename. Write the series
+	// under its pre-rename name and query it under the post-rename one.
+	appendSeries(t, wrapped, "http.server.duration", 1, 7.0, "http.response.status_code", "200")
+
+	q, err := wrapped.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	set := q.Select(context.Background(), false, nil,
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "http.server.request.duration"),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.22.0"),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	)
+	got := collectSeries(t, set)
+	require.Len(t, got, 1,
+		"expected the pre-rename series to surface under the queried name; zero means rename_metrics did not parse, got %v", got)
+	for k := range got {
+		require.Contains(t, k, `__name__="http.server.request.duration"`)
+	}
+
+	// Both versions declare the metric as s/histogram, so the rename is
+	// corroborated and nothing is reported.
+	require.Empty(t, warningStrings(set.Warnings()),
+		"a rename corroborated by the real semconv files must not warn")
+}
+
+// TestUpstreamSchemaAttributeRenameScope checks apply_to_metrics against the real
+// schema. Version 1.23.0 renames thread.daemon to jvm.thread.daemon for
+// jvm.thread.count only, so an unrelated metric must not have that attribute
+// rewritten.
+func TestUpstreamSchemaAttributeRenameScope(t *testing.T) {
+	underlying := teststorage.New(t)
+	wrapped, err := semconv.AwareStorageWithRegistry(underlying, upstreamRegistry(t))
+	require.NoError(t, err)
+
+	appendSeries(t, wrapped, "http.server.request.duration", 1, 7.0, "thread.daemon", "true")
+
+	q, err := wrapped.Querier(0, 10)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	set := q.Select(context.Background(), false, nil,
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "http.server.request.duration"),
+		labels.MustNewMatcher(labels.MatchEqual, "__semconv_url__", "registry/1.22.0"),
+		labels.MustNewMatcher(labels.MatchEqual, "__schema_url__", "registry/registry.yaml"),
+	)
+	got := collectSeries(t, set)
+	require.Len(t, got, 1, "got %v", got)
+	for k := range got {
+		require.Contains(t, k, `"thread.daemon"="true"`,
+			"a rename scoped to jvm.thread.count must not rewrite this metric's attribute")
+		require.NotContains(t, k, "jvm.thread.daemon")
+	}
+}


### PR DESCRIPTION
## Problem

Metric renames never parsed. `rename_metrics` was read as a struct with a `name_map`
field, and the file format has no such key: it maps each old metric name straight to
the new one, and only `rename_attributes` nests its mapping. The real upstream 1.44.0
schema yields zero metric renames across its 43 versions, while the 378 attribute
renames in the same file parse fine. Every fixture had been written to match the
parser rather than the format, so the suite passed while the feature did nothing on
real data.

A rename was also trusted on the strength of its names alone. The schema refers to
metrics only by name, so nothing separates a real rename from an edge that joins two
unrelated metrics which happened to share a name at different times. A name that was
renamed away is free to be reused later by a different metric, and the old edge then
pulls unrelated series into the result without saying so.

## Solution

Read `rename_metrics` the way the format defines it, then check each rename against
the semconv files before following it. `unit` and `instrument` describe what a metric
is rather than what it is called, and upstream forbids a stable metric from changing
either (`policies/compatibility.rego`), so a disagreement across an edge means the two
names denote different metrics.

Each hop is compared against the metric the query asked for, not against the other end
of the edge. An old edge can be entirely self-consistent and still have nothing to do
with the metric that now holds the name.

```mermaid
graph TD
  Q["Query a metric name,<br/>anchored at semconv 1.22.0"] --> D{"Does 1.22.0 declare<br/>that name as a metric?"}
  D -->|"yes<br/>http.server.request.duration"| ID["Identity of the queried metric:<br/><b>s / histogram</b>"]
  D -->|"no — 1.22.0 renamed it away<br/>http.server.duration"| E{"Does a version where that<br/>name is still current<br/>declare it?"}
  E -->|"yes, and any such<br/>versions agree"| ID
  E -->|"no, or they disagree<br/>(a retired name, reused)"| N["No identity to check against.<br/>Follow the renames unchecked,<br/>add a warning"]

  ID --> S["Changelog: 1.22.0 renamed<br/>http.server.duration to<br/>http.server.request.duration"]
  S --> L["Look up that name in the<br/>semconv it belongs to"]
  L --> U{"Is that semconv<br/>in the registry?"}
  U -->|"no"| P["Cannot verify.<br/>Proceed unchanged, silently"]
  U -->|"yes"| C{"Declared, with the same<br/>unit and instrument?"}
  C -->|"yes"| M["Fan out and merge<br/>under the queried name"]
  C -->|"not declared there"| WM["Merge anyway,<br/>add a warning"]
  C -->|"different"| W["Different metric.<br/>Skip it, add a warning"]

  style ID fill:#cfe2ff,stroke:#084298
  style M fill:#d4edda,stroke:#155724
  style W fill:#f8d7da,stroke:#721c24
  style P fill:#e2e3e5,stroke:#383d41
  style N fill:#fff3cd,stroke:#856404
  style WM fill:#fff3cd,stroke:#856404
```

A hop is rejected only on a positive contradiction, since fusing metrics measured in
different units gives meaningless numbers. Every other case is followed and merged,
with a warning where the check could not run.

PromQL behaviour does not change. Users still query by metric name.

```release-notes
NONE
```
